### PR TITLE
Set the default integration type to "TEST"

### DIFF
--- a/lib/OnePayBase.php
+++ b/lib/OnePayBase.php
@@ -16,10 +16,7 @@ class OnePayBase
     public static $scriptPath;
     public static $apiKey;
     public static $sharedSecret;
-    private static $integrationType = "MOCK";
-    /**
-     * Return the API key used for requests
-     */
+    private static $integrationType = "TEST";
 
     public static function integrationTypes($type = null) {
 

--- a/tests/RefundTest.php
+++ b/tests/RefundTest.php
@@ -10,6 +10,7 @@ final class RefundTest extends TestCase
     {
         OnePayBase::setSharedSecret("P4DCPS55QB2QLT56SQH6#W#LV76IAPYX");
         OnePayBase::setApiKey("mUc0GxYGor6X8u-_oB3e-HWJulRG01WoC96-_tUA3Bg");
+        OnePayBase::setCurrentIntegrationType("MOCK");
         $this->externalUniqueNumber = "1532376544050";
         $this->occ = "1807829988419927";
         $this->authorizationCode = "497490";

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -17,6 +17,7 @@ final class TransactionTest extends TestCase
     {
         OnePayBase::setSharedSecret("P4DCPS55QB2QLT56SQH6#W#LV76IAPYX");
         OnePayBase::setApiKey("mUc0GxYGor6X8u-_oB3e-HWJulRG01WoC96-_tUA3Bg");
+        OnePayBase::setCurrentIntegrationType("MOCK");
     }
 
     public function testTransactionRaisesWhenResponseIsNull() {


### PR DESCRIPTION
- Set the default integration type to "TEST"
- Set the integration type to "MOCK" on tests that do API calls