### PR TITLE
Modify README to add the release tag for the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ y luego requiriendo el SDK como dependencia:
     }
 ```
 
-O, si no deseas usar Composer, puedes descargar el código del SDK desde el repositorio y requerirlo directamente:
+O, si no deseas usar Composer, puedes descargar el código del release "1.0.0-pre" SDK [desde el repositorio](https://github.com/TransbankDevelopers/transbank-sdk-php/releases) y requerirlo directamente:
 ```php
 require_once('/directorio/del/sdk/init.php');
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Para usar el SDK en tu proyecto puedes usar Composer, por añadiendo el reposito
 y luego requiriendo el SDK como dependencia:
 ```json
     "require": {
-        "transbank-sdk": "dev-master"
+        "transbank-sdk": "dev-master#1.0.0-pre"
     }
 ```
 


### PR DESCRIPTION
- Modify the README file to note that the version to install as a
dependency should be "dev-master#1.0.0-pre" instead of "dev-master"