### PR TITLE
Verify installer hash using last signature from official site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ RUN apt-get update && apt-get install -y zip unzip
 RUN mkdir -p /sdk
 WORKDIR /sdk
 COPY . /sdk
+RUN php -r "copy('https://composer.github.io/installer.sig', 'composer-setup.sig');"
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-RUN php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+RUN php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('composer-setup.sig'))) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); unlink('composer-setup.sig'); } echo PHP_EOL;"
 RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer
 RUN php -r "unlink('composer-setup.php');"
-
+RUN php -r "unlink('composer-setup.sig');"


### PR DESCRIPTION
This PR fixes #25, downloading the signature from the official site and comparing it with the downloaded installer.