### PR TITLE
Set the webpay cert by environment when is empty

### DIFF
--- a/lib/webpay/Webpay.php
+++ b/lib/webpay/Webpay.php
@@ -67,6 +67,11 @@ class Webpay {
     function __construct($params) {
 
         $this->configuration = $params;
+
+        if (empty($this->configuration->getWebpayCert()))
+            $this->configuration->setWebpayCert(Webpay::defaultCert(
+                $this->configuration->getEnvironment())
+            );
     }
 
     public function getNormalTransaction() {


### PR DESCRIPTION
Unlike what it says in the documentation the sdk is not setting the WebPay certificate by environment when this is not assign. this change check if the certificate is empty and set this by the environment in the configuration.