### PR TITLE
Fix/fix onepay http response handling

### DIFF
--- a/lib/onepay/Refund.php
+++ b/lib/onepay/Refund.php
@@ -27,16 +27,21 @@ class Refund {
         $jsonRequest = json_encode($request, JSON_UNESCAPED_SLASHES);
         $http = new HttpClient();
         $path = self::TRANSACTION_BASE_PATH . self::REFUND_TRANSACTION;
+
         $httpResponse = $http->post(OnepayBase::getCurrentIntegrationTypeUrl(),
                                     $path,
                                     $jsonRequest);
-        $decodedResponse = json_decode($httpResponse, true);
-        if (!$decodedResponse || !$decodedResponse['responseCode']) {
+
+        $httpCode = $httpResponse->getStatusCode();
+        $responseJson = json_decode($httpResponse->getBody(), true);
+
+        if ($httpCode != 200 && $httpCode != 204) {
             throw new RefundCreateException("Could not obtain the service response");
         }
-        $refundCreateResponse = new RefundCreateResponse($decodedResponse);
-        if (strtolower($decodedResponse['responseCode']) != "ok") {
-            $msg = $decodedResponse['responseCode'] . " : " . $decodedResponse['description'];
+
+        $refundCreateResponse = new RefundCreateResponse($responseJson);
+        if (strtolower($responseJson['responseCode']) != "ok") {
+            $msg = $responseJson['responseCode'] . " : " . $responseJson['description'];
             throw new RefundCreateException($msg, -1);
         }
         return $refundCreateResponse;

--- a/lib/onepay/Transaction.php
+++ b/lib/onepay/Transaction.php
@@ -66,16 +66,19 @@ use Transbank\Utils\HttpClient;
         $options = OnepayRequestBuilder::getInstance()->buildOptions($options);
         $request = json_encode(OnepayRequestBuilder::getInstance()->buildCreateRequest($shoppingCart, $channel, $externalUniqueNumber, $options), JSON_UNESCAPED_SLASHES);
         $path = self::TRANSACTION_BASE_PATH . self::SEND_TRANSACTION;
-        $httpResponse = json_decode($http->post(OnepayBase::getCurrentIntegrationTypeUrl(), $path ,$request), true);
 
-        if (!$httpResponse) {
+        $httpResponse = $http->post(OnepayBase::getCurrentIntegrationTypeUrl(), $path ,$request);
+        $httpCode = $httpResponse->getStatusCode();
+        $responseJson = json_decode($httpResponse->getBody(), true);
+
+        if ($httpCode != 200 && $httpCode != 204) {
             throw new TransactionCreateException('Could not obtain a response from the service', -1);
         }
-        if($httpResponse['responseCode'] != "OK") {
-            throw new TransactionCreateException($httpResponse['responseCode'] . " : " . $httpResponse['description'], -1);
+        if($responseJson['responseCode'] != "OK") {
+            throw new TransactionCreateException($responseJson['responseCode'] . " : " . $responseJson['description'], -1);
         }
 
-        $transactionCreateResponse =  new TransactionCreateResponse($httpResponse);
+        $transactionCreateResponse =  new TransactionCreateResponse($responseJson);
         
         $signatureIsValid = OnepaySignUtil::getInstance()
                             ->validate($transactionCreateResponse,
@@ -92,16 +95,19 @@ use Transbank\Utils\HttpClient;
         $options = OnepayRequestBuilder::getInstance()->buildOptions($options);
         $request = json_encode(OnepayRequestBuilder::getInstance()->buildCommitRequest($occ, $externalUniqueNumber, $options), JSON_UNESCAPED_SLASHES);
         $path = self::TRANSACTION_BASE_PATH . self::COMMIT_TRANSACTION;
-        $httpResponse = json_decode($http->post(OnepayBase::getCurrentIntegrationTypeUrl(), $path, $request), true);
 
-        if (!$httpResponse) {
+        $httpResponse = $http->post(OnepayBase::getCurrentIntegrationTypeUrl(), $path ,$request);
+        $httpCode = $httpResponse->getStatusCode();
+        $responseJson = json_decode($httpResponse->getBody(), true);
+
+        if ($httpCode != 200 && $httpCode != 204) {
             throw new TransactionCommitException('Could not obtain a response from the service', -1);
         }
-        if($httpResponse['responseCode'] != "OK") {
-            throw new TransactionCommitException($httpResponse['responseCode'] . " : " . $httpResponse['description'], -1);
+        if($responseJson['responseCode'] != "OK") {
+            throw new TransactionCommitException($responseJson['responseCode'] . " : " . $responseJson['description'], -1);
         }
 
-        $transactionCommitResponse = new TransactionCommitResponse($httpResponse);
+        $transactionCommitResponse = new TransactionCommitResponse($responseJson);
         $signatureIsValid = OnepaySignUtil::getInstance()
                                           ->validate($transactionCommitResponse,
                                                      $options->getSharedSecret());

--- a/lib/utils/HttpClient.php
+++ b/lib/utils/HttpClient.php
@@ -11,7 +11,8 @@ class HttpClient {
 
         $fullPath = $url . $path;
         $basicHeader = ["Content-Type" => "application/json"];
-        $headers = array_merge($basicHeader, $options["headers"]);
+        $givenHeaders = isset($options["headers"]) ? $options["headers"] : [];
+        $headers = array_merge($basicHeader, $givenHeaders);
 
         $req = new Request('POST', $fullPath,  $headers, $data_to_send);
         $cl = new Client(['http_errors' => false]);
@@ -25,7 +26,8 @@ class HttpClient {
 
         $fullPath = $url . $path;
         $basicHeader = ["Content-Type" => "application/json"];
-        $headers = array_merge($basicHeader, $options["headers"]);
+        $givenHeaders = isset($options["headers"]) ? $options["headers"] : [];
+        $headers = array_merge($basicHeader, $givenHeaders);
 
         $req = new Request('PUT', $fullPath,  $headers, $data_to_send);
         $cl = new Client(['http_errors' => false]);
@@ -39,7 +41,8 @@ class HttpClient {
 
         $fullPath = $url . $path;
         $basicHeader = ["Content-Type" => "application/json"];
-        $headers = array_merge($basicHeader, $options["headers"]);
+        $givenHeaders = isset($options["headers"]) ? $options["headers"] : [];
+        $headers = array_merge($basicHeader, $givenHeaders);
 
         $req = new Request('GET', $fullPath,  $headers);
         $cl = new Client(['http_errors' => false]);
@@ -52,7 +55,8 @@ class HttpClient {
     {
         $fullPath = $url . $path;
         $basicHeader = ["Content-Type" => "application/json"];
-        $headers = array_merge($basicHeader, $options["headers"]);
+        $givenHeaders = isset($options["headers"]) ? $options["headers"] : [];
+        $headers = array_merge($basicHeader, $givenHeaders);
 
         $req = new Request('DELETE', $fullPath,  $headers, $data_to_send);
         $cl = new Client(['http_errors' => false]);

--- a/lib/utils/HttpClient.php
+++ b/lib/utils/HttpClient.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Psr7\Response;
 
 class HttpClient {
 
-    function post($url, $path, $data_to_send, $options = array('headers' => 0, 'transport' => 'https', 'port' => 443, 'proxy' => null)) {
+    function post($url, $path, $data_to_send, $options = null) {
 
         $fullPath = $url . $path;
         $basicHeader = ["Content-Type" => "application/json"];
@@ -21,7 +21,7 @@ class HttpClient {
         return $res;
     }
 
-    function put($url, $path, $data_to_send, $options = array('headers' => 0, 'transport' => 'https', 'port' => 443, 'proxy' => null))
+    function put($url, $path, $data_to_send, $options = null)
     {
 
         $fullPath = $url . $path;
@@ -36,7 +36,7 @@ class HttpClient {
         return $res;
     }
 
-    function get($url, $path, $options = array('headers' => 0, 'transport' => 'https', 'port' => 443, 'proxy' => null))
+    function get($url, $path, $options = null)
     {
 
         $fullPath = $url . $path;
@@ -51,7 +51,7 @@ class HttpClient {
         return $res;
     }
 
-    public function delete($url, $path, $data_to_send, $options = array('headers' => 0, 'transport' => 'https', 'port' => 443, 'proxy' => null))
+    public function delete($url, $path, $data_to_send, $options = null)
     {
         $fullPath = $url . $path;
         $basicHeader = ["Content-Type" => "application/json"];
@@ -64,19 +64,4 @@ class HttpClient {
         $res = $cl->send($req);
         return $res;
     }
-
-    public function toHeaderStrings($associativeArray)
-    {
-
-        $keys = array_keys($associativeArray);
-        $values = array_values($associativeArray);
-
-
-        $func = function($key, $value)
-        {
-            return  $key . ": " . $value;
-        };
-        return array_map($func, $keys, $values);
-    }
-
 }


### PR DESCRIPTION
Adapts Onepay to use Guzzle instead of `fopen`for HTTP calls