### PR TITLE
Fix/fix card number on responses

### DIFF
--- a/lib/webpay_rest/oneclick/MallInscription.php
+++ b/lib/webpay_rest/oneclick/MallInscription.php
@@ -46,7 +46,7 @@ class MallInscription
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -95,7 +95,7 @@ class MallInscription
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -146,7 +146,7 @@ class MallInscription
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {

--- a/lib/webpay_rest/oneclick/MallTransaction.php
+++ b/lib/webpay_rest/oneclick/MallTransaction.php
@@ -51,7 +51,7 @@ class MallTransaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -98,7 +98,7 @@ class MallTransaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -151,7 +151,7 @@ class MallTransaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {

--- a/lib/webpay_rest/webpay_plus/Transaction.php
+++ b/lib/webpay_rest/webpay_plus/Transaction.php
@@ -77,7 +77,7 @@ class Transaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -124,7 +124,7 @@ class Transaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -178,7 +178,7 @@ class Transaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -226,7 +226,7 @@ class Transaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -287,8 +287,7 @@ class Transaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $httpCode = $httpResponse->getStatusCode();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -337,7 +336,7 @@ class Transaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -396,7 +395,7 @@ class Transaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -444,7 +443,7 @@ class Transaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -499,7 +498,7 @@ class Transaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {
@@ -554,7 +553,7 @@ class Transaction
         $httpCode = $httpResponse->getStatusCode();
         if ($httpCode != 200 && $httpCode != 204) {
             $reason = $httpResponse->getReasonPhrase();
-            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode )";
+            $message = "Could not obtain a response from the service: $reason (HTTP code $httpCode)";
             $body = json_decode($httpResponse->getBody(), true);
 
             if (isset($body["error_message"])) {

--- a/lib/webpay_rest/webpay_plus/TransactionCommitResponse.php
+++ b/lib/webpay_rest/webpay_plus/TransactionCommitResponse.php
@@ -75,7 +75,7 @@ class TransactionCommitResponse
         $this->status = isset($json["status"]) ? $json["status"] : null;
         $this->buyOrder = isset($json["buy_order"]) ? $json["buy_order"] : null;
         $this->sessionId = isset($json["session_id"]) ?$json["session_id"] : null;
-        $this->cardNumber = isset($json["card_detail"]) ? (isset($json["card_detail"]["card_number"]) ? $json["card_detail"] : null) : null;
+        $this->cardNumber = isset($json["card_detail"]) ? (isset($json["card_detail"]["card_number"]) ? $json["card_detail"]["card_number"] : null) : null;
         $this->accountingDate = isset($json["accounting_date"]) ? $json["accounting_date"] : null;
         $this->transactionDate = isset($json["transaction_date"]) ? $json["transaction_date"] : null;
         $this->authorizationCode = isset($json["authorization_code"]) ? $json["authorization_code"] : null;

--- a/lib/webpay_rest/webpay_plus/WebpayPlus/TransactionMallStatusResponse.php
+++ b/lib/webpay_rest/webpay_plus/WebpayPlus/TransactionMallStatusResponse.php
@@ -18,7 +18,7 @@ class TransactionMallStatusResponse
     {
         $this->buyOrder = isset($json["buy_order"]) ? $json["buy_order"] : null;
         $this->sessionId = isset($json["session_id"]) ?$json["session_id"] : null;
-        $this->cardNumber = isset($json["card_detail"]) ? (isset($json["card_detail"]["card_number"]) ? $json["card_detail"] : null) : null;
+        $this->cardNumber = isset($json["card_detail"]) ? (isset($json["card_detail"]["card_number"]) ? $json["card_detail"]["card_number"] : null) : null;
         $this->expirationDate = isset($json["expiration_date"]) ? $json["expiration_date"] : null;
         $this->accountingDate = isset($json["accounting_date"]) ? $json["accounting_date"] : null;
         $this->transactionDate = isset($json["transaction_date"]) ? $json["transaction_date"] : null;


### PR DESCRIPTION
Make the responses that use `card_number` have the `card_number` on the `cardNumber` field, instead of having the `card_details` that the TBK API  returns