### PR TITLE
fix/add-compatibility-guzzlehttp-v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
       "ext-curl": "*",
       "ext-json": "*",
       "ext-mbstring": "*",
-      "guzzlehttp/guzzle":"^6.3.3"
+      "guzzlehttp/guzzle":"~6.0"
     },
     "require-dev": {
       "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Add suport guzzlehttp version >6.0 <7.0

Guzzlehttp support is added for versions greater than or equal to 6 and less than 7
because it is a library to commonly used in php and used another version not
especified in the SDK causes conflicts in developments already implement the
library.