### PR TITLE
Fix undefined variable on PHP 5.6 when cert_to_array has no serialNumberHex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,9 @@
       "ext-json": "*",
       "ext-soap": "*",
       "ext-mbstring": "*",
-      "guzzlehttp/guzzle":"~6.0"
-    },
+      "guzzlehttp/guzzle":"~6.0",
+      "ext-openssl": "*"
+  },
     "require-dev": {
       "phpunit/phpunit": "~4.0",
       "satooshi/php-coveralls": "~0.6.1",


### PR DESCRIPTION
Fix undefined variable on PHP 5.6 when cert_to_array has no serialNumberHex