### PR TITLE
Manually add OneClick class file to ensure can be autoloaded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
       "squizlabs/php_codesniffer": "~2.0"
     },
     "autoload": {
+      "files": ["lib/webpay_rest/oneclick/Oneclick.php"],
       "psr-4": {
         "Transbank\\": [
           "lib/"


### PR DESCRIPTION
When trying to use Transbank\Webpay\Oneclick, comoser can not autoload this class. I manually added the class file so composer can load this class.

Before this fix, trying to use this class throws the following error: Fatal error: Uncaught Error: Class 'Oneclick' not found. 