### PR TITLE
Feat/add rest support

### DIFF
--- a/lib/webpay_rest/Options.php
+++ b/lib/webpay_rest/Options.php
@@ -44,12 +44,13 @@ class Options
      * @var string $integrationType Sets the environment that the SDK is going
      * to point to (eg. TEST, LIVE, etc).
      */
-    public $integrationType = 'TEST';
+    public $integrationType = null;
 
-    public function __construct($apiKey, $commerceCode)
+    public function __construct($apiKey, $commerceCode, $integrationType = 'TEST')
     {
         $this->apiKey = $apiKey;
         $this->commerceCode = $commerceCode;
+        $this->integrationType = $integrationType;
     }
 
     /**

--- a/lib/webpay_rest/webpay_plus/WebpayPlus.php
+++ b/lib/webpay_rest/webpay_plus/WebpayPlus.php
@@ -110,7 +110,7 @@ class WebpayPlus
     public static function configureMallForTesting()
     {
         self::setApiKey(Options::DEFAULT_API_KEY);
-        self::setCommerceCode(Options::DEFAULT_MALL_COMMERCE_CODE);
+        self::setCommerceCode(Options::DEFAULT_WEBPAY_PLUS_MALL_COMMERCE_CODE);
         self::setIntegrationType(self::$INTEGRATION_TYPES["TEST"]);
     }
 


### PR DESCRIPTION
- Assigned the correct commerce_code for testing on Webpay Plus Mall (now it works).
- Modified the constructor of the class Options to be able to modify the integration_type.

Now it's possible to modify the existing integrations:
```php
WebpayPlus::$INTEGRATION_TYPES = [
            "LIVE" => "https://webpay3g.transbank.cl/",
            "TEST" => "https://webpay3gint.transbank.cl/",
            "NEW" => "https://new.integration.cl/",
        ];
```
Then work with the modifed integrations, as follows (before it only used the TEST integration):
```php
$options = new Options($apiKey, $commerceCode, "NEW");
$resp = Transaction::create($req["buy_order"], $req["session_id"], $req["amount"], $req["return_url"], $options);
```

By default, it will be used the TEST integration (if `$options` isn't specified).