### PR TITLE
Feature/psr4 namespaces

### DIFF
--- a/src/Onepay/Refund.php
+++ b/src/Onepay/Refund.php
@@ -6,7 +6,9 @@ namespace Transbank\Onepay;
  * class Refund
  * Model object for Refunds.
  */
+
 use Transbank\Onepay\Exceptions\RefundCreateException as RefundCreateException;
+use Transbank\Onepay\Utils\OnepayRequestBuilder;
 use Transbank\Utils\HttpClient;
 
 class Refund
@@ -22,16 +24,16 @@ class Refund
         $options = null
     ) {
         $request = OnepayRequestBuilder::getInstance()
-                                       ->buildRefundRequest(
-                                           $amount,
-                                           $occ,
-                                           $externalUniqueNumber,
-                                           $authorizationCode,
-                                           $options
-                                       );
+            ->buildRefundRequest(
+                $amount,
+                $occ,
+                $externalUniqueNumber,
+                $authorizationCode,
+                $options
+            );
         $jsonRequest = json_encode($request, JSON_UNESCAPED_SLASHES);
         $http = new HttpClient();
-        $path = self::TRANSACTION_BASE_PATH.self::REFUND_TRANSACTION;
+        $path = self::TRANSACTION_BASE_PATH . self::REFUND_TRANSACTION;
 
         $httpResponse = $http->post(
             OnepayBase::getCurrentIntegrationTypeUrl(),
@@ -47,7 +49,7 @@ class Refund
         }
         $refundCreateResponse = new RefundCreateResponse($responseJson);
         if (strtolower($responseJson['responseCode']) != 'ok') {
-            $msg = $responseJson['responseCode'].' : '.$responseJson['description'];
+            $msg = $responseJson['responseCode'] . ' : ' . $responseJson['description'];
 
             throw new RefundCreateException($msg, -1);
         }

--- a/src/Onepay/Refund.php
+++ b/src/Onepay/Refund.php
@@ -33,7 +33,7 @@ class Refund
             );
         $jsonRequest = json_encode($request, JSON_UNESCAPED_SLASHES);
         $http = new HttpClient();
-        $path = self::TRANSACTION_BASE_PATH . self::REFUND_TRANSACTION;
+        $path = self::TRANSACTION_BASE_PATH.self::REFUND_TRANSACTION;
 
         $httpResponse = $http->post(
             OnepayBase::getCurrentIntegrationTypeUrl(),
@@ -49,7 +49,7 @@ class Refund
         }
         $refundCreateResponse = new RefundCreateResponse($responseJson);
         if (strtolower($responseJson['responseCode']) != 'ok') {
-            $msg = $responseJson['responseCode'] . ' : ' . $responseJson['description'];
+            $msg = $responseJson['responseCode'].' : '.$responseJson['description'];
 
             throw new RefundCreateException($msg, -1);
         }

--- a/src/Onepay/Transaction.php
+++ b/src/Onepay/Transaction.php
@@ -26,7 +26,7 @@ class Transaction
 
     public static function getServiceUrl()
     {
-        return OnepayBase::getIntegrationTypeUrl('TEST') . '/ewallet-plugin-api-services/services/transactionservice';
+        return OnepayBase::getIntegrationTypeUrl('TEST').'/ewallet-plugin-api-services/services/transactionservice';
     }
 
     private static function getHttpClient()
@@ -41,8 +41,8 @@ class Transaction
     /**
      * @param $shoppingCart
      * @param ChannelEnum|null $channel
-     * @param null $externalUniqueNumber
-     * @param null $options
+     * @param null             $externalUniqueNumber
+     * @param null             $options
      *
      * @throws SignException
      * @throws TransactionCreateException
@@ -76,7 +76,7 @@ class Transaction
         $http = self::getHttpClient();
         $options = OnepayRequestBuilder::getInstance()->buildOptions($options);
         $request = json_encode(OnepayRequestBuilder::getInstance()->buildCreateRequest($shoppingCart, $channel, $externalUniqueNumber, $options), JSON_UNESCAPED_SLASHES);
-        $path = self::TRANSACTION_BASE_PATH . self::SEND_TRANSACTION;
+        $path = self::TRANSACTION_BASE_PATH.self::SEND_TRANSACTION;
 
         $httpResponse = $http->post(OnepayBase::getCurrentIntegrationTypeUrl(), $path, $request);
         if ($httpResponse === null) {
@@ -90,7 +90,7 @@ class Transaction
             throw new TransactionCreateException('Could not obtain a response from the service', -1);
         }
         if ($responseJson['responseCode'] != 'OK') {
-            throw new TransactionCreateException($responseJson['responseCode'] . ' : ' . $responseJson['description'], -1);
+            throw new TransactionCreateException($responseJson['responseCode'].' : '.$responseJson['description'], -1);
         }
 
         $transactionCreateResponse = new TransactionCreateResponse($responseJson);
@@ -112,7 +112,7 @@ class Transaction
         $http = self::getHttpClient();
         $options = OnepayRequestBuilder::getInstance()->buildOptions($options);
         $request = json_encode(OnepayRequestBuilder::getInstance()->buildCommitRequest($occ, $externalUniqueNumber, $options), JSON_UNESCAPED_SLASHES);
-        $path = self::TRANSACTION_BASE_PATH . self::COMMIT_TRANSACTION;
+        $path = self::TRANSACTION_BASE_PATH.self::COMMIT_TRANSACTION;
 
         $httpResponse = $http->post(OnepayBase::getCurrentIntegrationTypeUrl(), $path, $request);
         if ($httpResponse === null) {
@@ -125,7 +125,7 @@ class Transaction
             throw new TransactionCommitException('Could not obtain a response from the service', -1);
         }
         if ($responseJson['responseCode'] != 'OK') {
-            throw new TransactionCommitException($responseJson['responseCode'] . ' : ' . $responseJson['description'], -1);
+            throw new TransactionCommitException($responseJson['responseCode'].' : '.$responseJson['description'], -1);
         }
 
         $transactionCommitResponse = new TransactionCommitResponse($responseJson);

--- a/src/Onepay/Transaction.php
+++ b/src/Onepay/Transaction.php
@@ -8,133 +8,136 @@ namespace Transbank\Onepay;
  *
  * package @transbank;
  */
+
 use Transbank\Onepay\Exceptions\SignException;
 use Transbank\Onepay\Exceptions\TransactionCommitException;
 use Transbank\Onepay\Exceptions\TransactionCreateException;
+use Transbank\Onepay\Utils\OnepayRequestBuilder;
+use Transbank\Onepay\Utils\OnepaySignUtil;
 use Transbank\Utils\HttpClient;
 
- class Transaction
- {
-     const SEND_TRANSACTION = 'sendtransaction';
-     const COMMIT_TRANSACTION = 'gettransactionnumber';
-     const TRANSACTION_BASE_PATH = '/ewallet-plugin-api-services/services/transactionservice/';
+class Transaction
+{
+    const SEND_TRANSACTION = 'sendtransaction';
+    const COMMIT_TRANSACTION = 'gettransactionnumber';
+    const TRANSACTION_BASE_PATH = '/ewallet-plugin-api-services/services/transactionservice/';
 
-     private static $httpClient = null;
+    private static $httpClient = null;
 
-     public static function getServiceUrl()
-     {
-         return OnepayBase::getIntegrationTypeUrl('TEST').'/ewallet-plugin-api-services/services/transactionservice';
-     }
+    public static function getServiceUrl()
+    {
+        return OnepayBase::getIntegrationTypeUrl('TEST') . '/ewallet-plugin-api-services/services/transactionservice';
+    }
 
-     private static function getHttpClient()
-     {
-         if (!isset(self::$httpClient) || self::$httpClient == null) {
-             self::$httpClient = new HttpClient();
-         }
+    private static function getHttpClient()
+    {
+        if (!isset(self::$httpClient) || self::$httpClient == null) {
+            self::$httpClient = new HttpClient();
+        }
 
-         return self::$httpClient;
-     }
+        return self::$httpClient;
+    }
 
-     /**
-      * @param $shoppingCart
-      * @param ChannelEnum|null $channel
-      * @param null $externalUniqueNumber
-      * @param null $options
-      *
-      * @throws SignException
-      * @throws TransactionCreateException
-      * @throws \Exception
-      *
-      * @return TransactionCreateResponse
-      */
-     public static function create($shoppingCart, $channel = null, $externalUniqueNumber = null, $options = null)
-     {
-         if ($channel instanceof Options) {
-             $options = $channel;
-             $channel = null;
-         }
+    /**
+     * @param $shoppingCart
+     * @param ChannelEnum|null $channel
+     * @param null $externalUniqueNumber
+     * @param null $options
+     *
+     * @throws SignException
+     * @throws TransactionCreateException
+     * @throws \Exception
+     *
+     * @return TransactionCreateResponse
+     */
+    public static function create($shoppingCart, $channel = null, $externalUniqueNumber = null, $options = null)
+    {
+        if ($channel instanceof Options) {
+            $options = $channel;
+            $channel = null;
+        }
 
-         if ($externalUniqueNumber instanceof Options) {
-             $options = $externalUniqueNumber;
-             $externalUniqueNumber = null;
-         }
+        if ($externalUniqueNumber instanceof Options) {
+            $options = $externalUniqueNumber;
+            $externalUniqueNumber = null;
+        }
 
-         if (null != $channel && $channel == ChannelEnum::APP() && null == OnepayBase::getAppScheme()) {
-             throw new TransactionCreateException('You need to set an appScheme if you want to use the APP channel');
-         }
+        if (null != $channel && $channel == ChannelEnum::APP() && null == OnepayBase::getAppScheme()) {
+            throw new TransactionCreateException('You need to set an appScheme if you want to use the APP channel');
+        }
 
-         if (null != $channel && $channel == ChannelEnum::MOBILE() && null == OnepayBase::getCallbackUrl()) {
-             throw new TransactionCreateException('You need to set a valid callback if you want to use the MOBILE channel');
-         }
+        if (null != $channel && $channel == ChannelEnum::MOBILE() && null == OnepayBase::getCallbackUrl()) {
+            throw new TransactionCreateException('You need to set a valid callback if you want to use the MOBILE channel');
+        }
 
-         if (!$shoppingCart instanceof ShoppingCart) {
-             throw new \Exception('Shopping cart is null or empty');
-         }
-         $http = self::getHttpClient();
-         $options = OnepayRequestBuilder::getInstance()->buildOptions($options);
-         $request = json_encode(OnepayRequestBuilder::getInstance()->buildCreateRequest($shoppingCart, $channel, $externalUniqueNumber, $options), JSON_UNESCAPED_SLASHES);
-         $path = self::TRANSACTION_BASE_PATH.self::SEND_TRANSACTION;
+        if (!$shoppingCart instanceof ShoppingCart) {
+            throw new \Exception('Shopping cart is null or empty');
+        }
+        $http = self::getHttpClient();
+        $options = OnepayRequestBuilder::getInstance()->buildOptions($options);
+        $request = json_encode(OnepayRequestBuilder::getInstance()->buildCreateRequest($shoppingCart, $channel, $externalUniqueNumber, $options), JSON_UNESCAPED_SLASHES);
+        $path = self::TRANSACTION_BASE_PATH . self::SEND_TRANSACTION;
 
-         $httpResponse = $http->post(OnepayBase::getCurrentIntegrationTypeUrl(), $path, $request);
-         if ($httpResponse === null) {
-             throw new TransactionCreateException('Could not obtain a response from the service', -1);
-         }
+        $httpResponse = $http->post(OnepayBase::getCurrentIntegrationTypeUrl(), $path, $request);
+        if ($httpResponse === null) {
+            throw new TransactionCreateException('Could not obtain a response from the service', -1);
+        }
 
-         $httpCode = $httpResponse->getStatusCode();
-         $responseJson = json_decode($httpResponse->getBody(), true);
+        $httpCode = $httpResponse->getStatusCode();
+        $responseJson = json_decode($httpResponse->getBody(), true);
 
-         if ($httpCode != 200 && $httpCode != 204) {
-             throw new TransactionCreateException('Could not obtain a response from the service', -1);
-         }
-         if ($responseJson['responseCode'] != 'OK') {
-             throw new TransactionCreateException($responseJson['responseCode'].' : '.$responseJson['description'], -1);
-         }
+        if ($httpCode != 200 && $httpCode != 204) {
+            throw new TransactionCreateException('Could not obtain a response from the service', -1);
+        }
+        if ($responseJson['responseCode'] != 'OK') {
+            throw new TransactionCreateException($responseJson['responseCode'] . ' : ' . $responseJson['description'], -1);
+        }
 
-         $transactionCreateResponse = new TransactionCreateResponse($responseJson);
+        $transactionCreateResponse = new TransactionCreateResponse($responseJson);
 
-         $signatureIsValid = OnepaySignUtil::getInstance()
-                            ->validate(
-                                $transactionCreateResponse,
-                                $options->getSharedSecret()
-                            );
-         if (!$signatureIsValid) {
-             throw new SignException('The response signature is not valid.', -1);
-         }
+        $signatureIsValid = OnepaySignUtil::getInstance()
+            ->validate(
+                $transactionCreateResponse,
+                $options->getSharedSecret()
+            );
+        if (!$signatureIsValid) {
+            throw new SignException('The response signature is not valid.', -1);
+        }
 
-         return $transactionCreateResponse;
-     }
+        return $transactionCreateResponse;
+    }
 
-     public static function commit($occ, $externalUniqueNumber, $options = null)
-     {
-         $http = self::getHttpClient();
-         $options = OnepayRequestBuilder::getInstance()->buildOptions($options);
-         $request = json_encode(OnepayRequestBuilder::getInstance()->buildCommitRequest($occ, $externalUniqueNumber, $options), JSON_UNESCAPED_SLASHES);
-         $path = self::TRANSACTION_BASE_PATH.self::COMMIT_TRANSACTION;
+    public static function commit($occ, $externalUniqueNumber, $options = null)
+    {
+        $http = self::getHttpClient();
+        $options = OnepayRequestBuilder::getInstance()->buildOptions($options);
+        $request = json_encode(OnepayRequestBuilder::getInstance()->buildCommitRequest($occ, $externalUniqueNumber, $options), JSON_UNESCAPED_SLASHES);
+        $path = self::TRANSACTION_BASE_PATH . self::COMMIT_TRANSACTION;
 
-         $httpResponse = $http->post(OnepayBase::getCurrentIntegrationTypeUrl(), $path, $request);
-         if ($httpResponse === null) {
-             throw new TransactionCommitException('Could not obtain a response from the service', -1);
-         }
-         $httpCode = $httpResponse->getStatusCode();
-         $responseJson = json_decode($httpResponse->getBody(), true);
+        $httpResponse = $http->post(OnepayBase::getCurrentIntegrationTypeUrl(), $path, $request);
+        if ($httpResponse === null) {
+            throw new TransactionCommitException('Could not obtain a response from the service', -1);
+        }
+        $httpCode = $httpResponse->getStatusCode();
+        $responseJson = json_decode($httpResponse->getBody(), true);
 
-         if ($httpCode != 200 && $httpCode != 204) {
-             throw new TransactionCommitException('Could not obtain a response from the service', -1);
-         }
-         if ($responseJson['responseCode'] != 'OK') {
-             throw new TransactionCommitException($responseJson['responseCode'].' : '.$responseJson['description'], -1);
-         }
+        if ($httpCode != 200 && $httpCode != 204) {
+            throw new TransactionCommitException('Could not obtain a response from the service', -1);
+        }
+        if ($responseJson['responseCode'] != 'OK') {
+            throw new TransactionCommitException($responseJson['responseCode'] . ' : ' . $responseJson['description'], -1);
+        }
 
-         $transactionCommitResponse = new TransactionCommitResponse($responseJson);
-         $signatureIsValid = OnepaySignUtil::getInstance()
-                                          ->validate(
-                                              $transactionCommitResponse,
-                                              $options->getSharedSecret()
-                                          );
-         if (!$signatureIsValid) {
-             throw new SignException('The response signature is not valid', -1);
-         }
+        $transactionCommitResponse = new TransactionCommitResponse($responseJson);
+        $signatureIsValid = OnepaySignUtil::getInstance()
+            ->validate(
+                $transactionCommitResponse,
+                $options->getSharedSecret()
+            );
+        if (!$signatureIsValid) {
+            throw new SignException('The response signature is not valid', -1);
+        }
 
-         return $transactionCommitResponse;
-     }
- }
+        return $transactionCommitResponse;
+    }
+}

--- a/src/Onepay/Utils/OnepayRequestBuilder.php
+++ b/src/Onepay/Utils/OnepayRequestBuilder.php
@@ -3,7 +3,6 @@
 namespace Transbank\Onepay\Utils;
 
 use Transbank\Onepay\OnepayBase;
-use Transbank\Onepay\Utils\OnepaySignUtil;
 use Transbank\Onepay\Options;
 use Transbank\Onepay\RefundCreateRequest;
 use Transbank\Onepay\TransactionCommitRequest;

--- a/src/Onepay/Utils/OnepaySignUtil.php
+++ b/src/Onepay/Utils/OnepaySignUtil.php
@@ -1,200 +1,206 @@
 <?php
 
-namespace Transbank\Onepay;
+namespace Transbank\Onepay\Utils;
 
 use Transbank\Onepay\Exceptions\SignException as SignException;
+use Transbank\Onepay\OnepayBase;
+use Transbank\Onepay\RefundCreateRequest;
+use Transbank\Onepay\TransactionCommitRequest;
+use Transbank\Onepay\TransactionCommitResponse;
+use Transbank\Onepay\TransactionCreateRequest;
+use Transbank\Onepay\TransactionCreateResponse;
 
- /**
-  * class OnepaySignUtil;.
-  */
- class OnepaySignUtil
- {
-     // Make this be a singleton class
-     protected static $instance = null;
+/**
+ * class OnepaySignUtil;.
+ */
+class OnepaySignUtil
+{
+    // Make this be a singleton class
+    protected static $instance = null;
 
-     protected function __construct()
-     {
-     }
+    protected function __construct()
+    {
+    }
 
-     protected function __clone()
-     {
-     }
+    protected function __clone()
+    {
+    }
 
-     public static function getInstance()
-     {
-         if (!isset(static::$instance)) {
-             static::$instance = new static();
-         }
+    public static function getInstance()
+    {
+        if (!isset(static::$instance)) {
+            static::$instance = new static();
+        }
 
-         return static::$instance;
-     }
+        return static::$instance;
+    }
 
-     public function sign($requestToSign, $secret)
-     {
-         if (!$secret) {
-             throw new SignException('Parameter \'$secret\' must not be null');
-         }
+    public function sign($requestToSign, $secret)
+    {
+        if (!$secret) {
+            throw new SignException('Parameter \'$secret\' must not be null');
+        }
 
-         if ($requestToSign instanceof TransactionCreateRequest) {
-             return self::getInstance()->signTransactionCreateRequest($requestToSign, $secret);
-         }
+        if ($requestToSign instanceof TransactionCreateRequest) {
+            return self::getInstance()->signTransactionCreateRequest($requestToSign, $secret);
+        }
 
-         if ($requestToSign instanceof TransactionCommitRequest) {
-             return self::getInstance()->signTransactionCommitRequest($requestToSign, $secret);
-         }
+        if ($requestToSign instanceof TransactionCommitRequest) {
+            return self::getInstance()->signTransactionCommitRequest($requestToSign, $secret);
+        }
 
-         if ($requestToSign instanceof RefundCreateRequest) {
-             return self::getInstance()->signRefundCreateRequest($requestToSign, $secret);
-         }
+        if ($requestToSign instanceof RefundCreateRequest) {
+            return self::getInstance()->signRefundCreateRequest($requestToSign, $secret);
+        }
 
-         throw new SignException('Parameter \'$requestToSign\' must be a TransactionCreateRequest or TransactionCommitRequest');
-     }
+        throw new SignException('Parameter \'$requestToSign\' must be a TransactionCreateRequest or TransactionCommitRequest');
+    }
 
-     private function signTransactionCreateRequest($transactionCreateRequest, $secret)
-     {
-         $signature = $this->buildSignature($transactionCreateRequest, $secret);
+    private function signTransactionCreateRequest($transactionCreateRequest, $secret)
+    {
+        $signature = $this->buildSignature($transactionCreateRequest, $secret);
 
-         return $transactionCreateRequest->setSignature($signature);
-     }
+        return $transactionCreateRequest->setSignature($signature);
+    }
 
-     private function signTransactionCommitRequest($transactionCommitRequest, $secret)
-     {
-         $signature = $this->buildSignatureTransactionCommitRequestOrCreateResponse(
-             $transactionCommitRequest,
-             $secret
-         );
+    private function signTransactionCommitRequest($transactionCommitRequest, $secret)
+    {
+        $signature = $this->buildSignatureTransactionCommitRequestOrCreateResponse(
+            $transactionCommitRequest,
+            $secret
+        );
 
-         return $transactionCommitRequest->setSignature($signature);
-     }
+        return $transactionCommitRequest->setSignature($signature);
+    }
 
-     private function signRefundCreateRequest($refundCreateRequest, $secret)
-     {
-         $signature = $this->buildSignatureRefundCreateRequest(
-             $refundCreateRequest,
-             $secret
-         );
+    private function signRefundCreateRequest($refundCreateRequest, $secret)
+    {
+        $signature = $this->buildSignatureRefundCreateRequest(
+            $refundCreateRequest,
+            $secret
+        );
 
-         return $refundCreateRequest->setSignature($signature);
-     }
+        return $refundCreateRequest->setSignature($signature);
+    }
 
-     public function validate($signable, $secret)
-     {
-         if ($signable instanceof TransactionCreateResponse) {
-             $signed = $this->buildSignature($signable, $secret);
-         } elseif ($signable instanceof TransactionCommitResponse) {
-             $signed = $this->buildSignature($signable, $secret);
-         } else {
-             throw new SignException('Given signable object is not validatable.');
-         }
+    public function validate($signable, $secret)
+    {
+        if ($signable instanceof TransactionCreateResponse) {
+            $signed = $this->buildSignature($signable, $secret);
+        } elseif ($signable instanceof TransactionCommitResponse) {
+            $signed = $this->buildSignature($signable, $secret);
+        } else {
+            throw new SignException('Given signable object is not validatable.');
+        }
 
-         return $signable->getSignature() == $signed;
-     }
+        return $signable->getSignature() == $signed;
+    }
 
-     private function buildSignature($signable, $secret)
-     {
-         if ($signable instanceof TransactionCommitRequest || $signable instanceof TransactionCreateResponse) {
-             // Both the TransactionCommitRequest and TransactionCreateResponse
-             // build their signatures the same way.
-             return $this->buildSignatureTransactionCommitRequestOrCreateResponse($signable, $secret);
-         } elseif ($signable instanceof TransactionCreateRequest) {
-             return $this->buildSignatureTransactionCreateRequest($signable, $secret);
-         } elseif ($signable instanceof TransactionCommitResponse) {
-             return $this->buildSignatureTransactionCommitResponse($signable, $secret);
-         } else {
-             throw new SignException('Unknown type of signable.');
-         }
-     }
+    private function buildSignature($signable, $secret)
+    {
+        if ($signable instanceof TransactionCommitRequest || $signable instanceof TransactionCreateResponse) {
+            // Both the TransactionCommitRequest and TransactionCreateResponse
+            // build their signatures the same way.
+            return $this->buildSignatureTransactionCommitRequestOrCreateResponse($signable, $secret);
+        } elseif ($signable instanceof TransactionCreateRequest) {
+            return $this->buildSignatureTransactionCreateRequest($signable, $secret);
+        } elseif ($signable instanceof TransactionCommitResponse) {
+            return $this->buildSignatureTransactionCommitResponse($signable, $secret);
+        } else {
+            throw new SignException('Unknown type of signable.');
+        }
+    }
 
-     private function buildSignatureTransactionCommitRequestOrCreateResponse($signable, $secret)
-     {
-         if (!$signable instanceof TransactionCommitRequest && !$signable instanceof TransactionCreateResponse) {
-             throw new SignException('Invalid type of signable. Type must be TransactionCommitRequest or TransactionCreateResponse');
-         }
+    private function buildSignatureTransactionCommitRequestOrCreateResponse($signable, $secret)
+    {
+        if (!$signable instanceof TransactionCommitRequest && !$signable instanceof TransactionCreateResponse) {
+            throw new SignException('Invalid type of signable. Type must be TransactionCommitRequest or TransactionCreateResponse');
+        }
 
-         $occ = $signable->getOcc();
-         $externalUniqueNumber = $signable->getExternalUniqueNumber();
-         $issuedAtAsString = (string) $signable->getIssuedAt();
+        $occ = $signable->getOcc();
+        $externalUniqueNumber = $signable->getExternalUniqueNumber();
+        $issuedAtAsString = (string) $signable->getIssuedAt();
 
-         if (!$occ || !$externalUniqueNumber) {
-             throw new SignException('occ / externalUniqueNumber cannot be null.');
-         }
+        if (!$occ || !$externalUniqueNumber) {
+            throw new SignException('occ / externalUniqueNumber cannot be null.');
+        }
 
-         $data = mb_strlen($occ).$occ;
-         $data .= mb_strlen($externalUniqueNumber).$externalUniqueNumber;
-         $data .= mb_strlen($issuedAtAsString).$issuedAtAsString;
+        $data = mb_strlen($occ) . $occ;
+        $data .= mb_strlen($externalUniqueNumber) . $externalUniqueNumber;
+        $data .= mb_strlen($issuedAtAsString) . $issuedAtAsString;
 
-         return base64_encode(hash_hmac('sha256', $data, $secret, true));
-     }
+        return base64_encode(hash_hmac('sha256', $data, $secret, true));
+    }
 
-     private function buildSignatureTransactionCreateRequest($signable, $secret)
-     {
-         if (!$signable instanceof TransactionCreateRequest) {
-             throw new SignException('Invalid signable. Accepted type: TransactionCreateRequest');
-         }
+    private function buildSignatureTransactionCreateRequest($signable, $secret)
+    {
+        if (!$signable instanceof TransactionCreateRequest) {
+            throw new SignException('Invalid signable. Accepted type: TransactionCreateRequest');
+        }
 
-         $externalUniqueNumberAsString = (string) $signable->getExternalUniqueNumber();
-         $totalAsString = (string) $signable->getTotal();
-         $itemsQuantityAsString = (string) $signable->getItemsQuantity();
-         $issuedAtAsString = (string) $signable->getIssuedAt();
+        $externalUniqueNumberAsString = (string) $signable->getExternalUniqueNumber();
+        $totalAsString = (string) $signable->getTotal();
+        $itemsQuantityAsString = (string) $signable->getItemsQuantity();
+        $issuedAtAsString = (string) $signable->getIssuedAt();
 
-         $data = mb_strlen($externalUniqueNumberAsString).$externalUniqueNumberAsString;
-         $data .= mb_strlen($totalAsString).$totalAsString;
-         $data .= mb_strlen($itemsQuantityAsString).$itemsQuantityAsString;
-         $data .= mb_strlen($issuedAtAsString).$issuedAtAsString;
-         $data .= mb_strlen(OnepayBase::getCallbackUrl()).OnepayBase::getCallbackUrl();
+        $data = mb_strlen($externalUniqueNumberAsString) . $externalUniqueNumberAsString;
+        $data .= mb_strlen($totalAsString) . $totalAsString;
+        $data .= mb_strlen($itemsQuantityAsString) . $itemsQuantityAsString;
+        $data .= mb_strlen($issuedAtAsString) . $issuedAtAsString;
+        $data .= mb_strlen(OnepayBase::getCallbackUrl()) . OnepayBase::getCallbackUrl();
 
-         $crypted = hash_hmac('sha256', $data, $secret, true);
+        $crypted = hash_hmac('sha256', $data, $secret, true);
 
-         return base64_encode($crypted);
-     }
+        return base64_encode($crypted);
+    }
 
-     private function buildSignatureTransactionCommitResponse($signable, $secret)
-     {
-         if (!$signable instanceof TransactionCommitResponse) {
-             throw new SignException('Invalid signable. Accepted type: TransactionCommitResponse');
-         }
+    private function buildSignatureTransactionCommitResponse($signable, $secret)
+    {
+        if (!$signable instanceof TransactionCommitResponse) {
+            throw new SignException('Invalid signable. Accepted type: TransactionCommitResponse');
+        }
 
-         $occ = $signable->getOcc();
-         $authorizationCode = $signable->getAuthorizationCode();
-         $issuedAtAsString = (string) $signable->getIssuedAt();
-         $amountAsString = (string) $signable->getAmount();
-         $installmentsAmountAsString = (string) $signable->getInstallmentsAmount();
-         $installmentsNumberAsString = (string) $signable->getInstallmentsNumber();
-         $buyOrder = (string) $signable->getBuyOrder();
+        $occ = $signable->getOcc();
+        $authorizationCode = $signable->getAuthorizationCode();
+        $issuedAtAsString = (string) $signable->getIssuedAt();
+        $amountAsString = (string) $signable->getAmount();
+        $installmentsAmountAsString = (string) $signable->getInstallmentsAmount();
+        $installmentsNumberAsString = (string) $signable->getInstallmentsNumber();
+        $buyOrder = (string) $signable->getBuyOrder();
 
-         $data = mb_strlen($occ).$occ;
-         $data .= mb_strlen($authorizationCode).$authorizationCode;
-         $data .= mb_strlen($issuedAtAsString).$issuedAtAsString;
-         $data .= mb_strlen($amountAsString).$amountAsString;
-         $data .= mb_strlen($installmentsAmountAsString).$installmentsAmountAsString;
-         $data .= mb_strlen($installmentsNumberAsString).$installmentsNumberAsString;
-         $data .= mb_strlen($buyOrder).$buyOrder;
+        $data = mb_strlen($occ) . $occ;
+        $data .= mb_strlen($authorizationCode) . $authorizationCode;
+        $data .= mb_strlen($issuedAtAsString) . $issuedAtAsString;
+        $data .= mb_strlen($amountAsString) . $amountAsString;
+        $data .= mb_strlen($installmentsAmountAsString) . $installmentsAmountAsString;
+        $data .= mb_strlen($installmentsNumberAsString) . $installmentsNumberAsString;
+        $data .= mb_strlen($buyOrder) . $buyOrder;
 
-         $crypted = hash_hmac('sha256', $data, $secret, true);
+        $crypted = hash_hmac('sha256', $data, $secret, true);
 
-         return base64_encode($crypted);
-     }
+        return base64_encode($crypted);
+    }
 
-     private function buildSignatureRefundCreateRequest($signable, $secret)
-     {
-         if (!$signable instanceof RefundCreateRequest) {
-             throw new SignException('Invalid type of signable. Type must be RefundCreateRequest');
-         }
+    private function buildSignatureRefundCreateRequest($signable, $secret)
+    {
+        if (!$signable instanceof RefundCreateRequest) {
+            throw new SignException('Invalid type of signable. Type must be RefundCreateRequest');
+        }
 
-         $occ = $signable->getOcc();
-         $externalUniqueNumber = $signable->getExternalUniqueNumber();
-         $authorizationCode = $signable->getAuthorizationCode();
-         $issuedAtAsString = (string) $signable->getIssuedAt();
-         $refundAmountAsString = (string) $signable->getNullifyAmount();
+        $occ = $signable->getOcc();
+        $externalUniqueNumber = $signable->getExternalUniqueNumber();
+        $authorizationCode = $signable->getAuthorizationCode();
+        $issuedAtAsString = (string) $signable->getIssuedAt();
+        $refundAmountAsString = (string) $signable->getNullifyAmount();
 
-         $data = mb_strlen($occ).$occ;
-         $data .= mb_strlen($externalUniqueNumber).$externalUniqueNumber;
-         $data .= mb_strlen($authorizationCode).$authorizationCode;
-         $data .= mb_strlen($issuedAtAsString).$issuedAtAsString;
-         $data .= mb_strlen($refundAmountAsString).$refundAmountAsString;
+        $data = mb_strlen($occ) . $occ;
+        $data .= mb_strlen($externalUniqueNumber) . $externalUniqueNumber;
+        $data .= mb_strlen($authorizationCode) . $authorizationCode;
+        $data .= mb_strlen($issuedAtAsString) . $issuedAtAsString;
+        $data .= mb_strlen($refundAmountAsString) . $refundAmountAsString;
 
-         $crypted = hash_hmac('sha256', $data, $secret, true);
+        $crypted = hash_hmac('sha256', $data, $secret, true);
 
-         return base64_encode($crypted);
-     }
- }
+        return base64_encode($crypted);
+    }
+}

--- a/src/Onepay/Utils/OnepaySignUtil.php
+++ b/src/Onepay/Utils/OnepaySignUtil.php
@@ -125,9 +125,9 @@ class OnepaySignUtil
             throw new SignException('occ / externalUniqueNumber cannot be null.');
         }
 
-        $data = mb_strlen($occ) . $occ;
-        $data .= mb_strlen($externalUniqueNumber) . $externalUniqueNumber;
-        $data .= mb_strlen($issuedAtAsString) . $issuedAtAsString;
+        $data = mb_strlen($occ).$occ;
+        $data .= mb_strlen($externalUniqueNumber).$externalUniqueNumber;
+        $data .= mb_strlen($issuedAtAsString).$issuedAtAsString;
 
         return base64_encode(hash_hmac('sha256', $data, $secret, true));
     }
@@ -143,11 +143,11 @@ class OnepaySignUtil
         $itemsQuantityAsString = (string) $signable->getItemsQuantity();
         $issuedAtAsString = (string) $signable->getIssuedAt();
 
-        $data = mb_strlen($externalUniqueNumberAsString) . $externalUniqueNumberAsString;
-        $data .= mb_strlen($totalAsString) . $totalAsString;
-        $data .= mb_strlen($itemsQuantityAsString) . $itemsQuantityAsString;
-        $data .= mb_strlen($issuedAtAsString) . $issuedAtAsString;
-        $data .= mb_strlen(OnepayBase::getCallbackUrl()) . OnepayBase::getCallbackUrl();
+        $data = mb_strlen($externalUniqueNumberAsString).$externalUniqueNumberAsString;
+        $data .= mb_strlen($totalAsString).$totalAsString;
+        $data .= mb_strlen($itemsQuantityAsString).$itemsQuantityAsString;
+        $data .= mb_strlen($issuedAtAsString).$issuedAtAsString;
+        $data .= mb_strlen(OnepayBase::getCallbackUrl()).OnepayBase::getCallbackUrl();
 
         $crypted = hash_hmac('sha256', $data, $secret, true);
 
@@ -168,13 +168,13 @@ class OnepaySignUtil
         $installmentsNumberAsString = (string) $signable->getInstallmentsNumber();
         $buyOrder = (string) $signable->getBuyOrder();
 
-        $data = mb_strlen($occ) . $occ;
-        $data .= mb_strlen($authorizationCode) . $authorizationCode;
-        $data .= mb_strlen($issuedAtAsString) . $issuedAtAsString;
-        $data .= mb_strlen($amountAsString) . $amountAsString;
-        $data .= mb_strlen($installmentsAmountAsString) . $installmentsAmountAsString;
-        $data .= mb_strlen($installmentsNumberAsString) . $installmentsNumberAsString;
-        $data .= mb_strlen($buyOrder) . $buyOrder;
+        $data = mb_strlen($occ).$occ;
+        $data .= mb_strlen($authorizationCode).$authorizationCode;
+        $data .= mb_strlen($issuedAtAsString).$issuedAtAsString;
+        $data .= mb_strlen($amountAsString).$amountAsString;
+        $data .= mb_strlen($installmentsAmountAsString).$installmentsAmountAsString;
+        $data .= mb_strlen($installmentsNumberAsString).$installmentsNumberAsString;
+        $data .= mb_strlen($buyOrder).$buyOrder;
 
         $crypted = hash_hmac('sha256', $data, $secret, true);
 
@@ -193,11 +193,11 @@ class OnepaySignUtil
         $issuedAtAsString = (string) $signable->getIssuedAt();
         $refundAmountAsString = (string) $signable->getNullifyAmount();
 
-        $data = mb_strlen($occ) . $occ;
-        $data .= mb_strlen($externalUniqueNumber) . $externalUniqueNumber;
-        $data .= mb_strlen($authorizationCode) . $authorizationCode;
-        $data .= mb_strlen($issuedAtAsString) . $issuedAtAsString;
-        $data .= mb_strlen($refundAmountAsString) . $refundAmountAsString;
+        $data = mb_strlen($occ).$occ;
+        $data .= mb_strlen($externalUniqueNumber).$externalUniqueNumber;
+        $data .= mb_strlen($authorizationCode).$authorizationCode;
+        $data .= mb_strlen($issuedAtAsString).$issuedAtAsString;
+        $data .= mb_strlen($refundAmountAsString).$refundAmountAsString;
 
         $crypted = hash_hmac('sha256', $data, $secret, true);
 

--- a/src/Patpass/PatpassByWebpay/Transaction.php
+++ b/src/Patpass/PatpassByWebpay/Transaction.php
@@ -7,6 +7,8 @@ use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionCommitException;
 use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionCreateException;
 use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionStatusException;
 use Transbank\Patpass\PatpassByWebpay\Responses\TransactionCommitResponse;
+use Transbank\Patpass\PatpassByWebpay\Responses\TransactionCreateResponse;
+use Transbank\Patpass\PatpassByWebpay\Responses\TransactionStatusResponse;
 
 class Transaction
 {
@@ -90,7 +92,7 @@ class Transaction
         $http = PatpassByWebpay::getHttpClient();
         $httpResponse = $http->put(
             $baseUrl,
-            self::COMMIT_TRANSACTION_ENDPOINT.'/'.$token,
+            self::COMMIT_TRANSACTION_ENDPOINT . '/' . $token,
             null,
             ['headers' => $headers]
         );

--- a/src/Patpass/PatpassByWebpay/Transaction.php
+++ b/src/Patpass/PatpassByWebpay/Transaction.php
@@ -92,7 +92,7 @@ class Transaction
         $http = PatpassByWebpay::getHttpClient();
         $httpResponse = $http->put(
             $baseUrl,
-            self::COMMIT_TRANSACTION_ENDPOINT . '/' . $token,
+            self::COMMIT_TRANSACTION_ENDPOINT.'/'.$token,
             null,
             ['headers' => $headers]
         );

--- a/tests/OnepaySignUtilTest.php
+++ b/tests/OnepaySignUtilTest.php
@@ -3,16 +3,17 @@
 namespace Transbank\Onepay;
 
 use PHPUnit\Framework\TestCase;
+use Transbank\Onepay\Utils\OnepaySignUtil;
 
-require_once __DIR__.'/mocks/TransactionCreateRequestMocks.php';
-require_once __DIR__.'/mocks/TransactionCommitRequestMocks.php';
-require_once __DIR__.'/mocks/ShoppingCartMocks.php';
-require_once __DIR__.'/mocks/TransactionCreateResponseMocks.php';
-require_once __DIR__.'/mocks/TransactionCommitResponseMocks.php';
+require_once __DIR__ . '/mocks/TransactionCreateRequestMocks.php';
+require_once __DIR__ . '/mocks/TransactionCommitRequestMocks.php';
+require_once __DIR__ . '/mocks/ShoppingCartMocks.php';
+require_once __DIR__ . '/mocks/TransactionCreateResponseMocks.php';
+require_once __DIR__ . '/mocks/TransactionCommitResponseMocks.php';
 
 final class OnepaySignUtilTest extends TestCase
 {
-    protected function setup()
+    protected function setup(): void
     {
         OnepayBase::setSharedSecret('P4DCPS55QB2QLT56SQH6#W#LV76IAPYX');
         OnepayBase::setApiKey('mUc0GxYGor6X8u-_oB3e-HWJulRG01WoC96-_tUA3Bg');

--- a/tests/OnepaySignUtilTest.php
+++ b/tests/OnepaySignUtilTest.php
@@ -13,7 +13,7 @@ require_once __DIR__.'/mocks/TransactionCommitResponseMocks.php';
 
 final class OnepaySignUtilTest extends TestCase
 {
-    protected function setup(): void
+    protected function setup()
     {
         OnepayBase::setSharedSecret('P4DCPS55QB2QLT56SQH6#W#LV76IAPYX');
         OnepayBase::setApiKey('mUc0GxYGor6X8u-_oB3e-HWJulRG01WoC96-_tUA3Bg');

--- a/tests/OnepaySignUtilTest.php
+++ b/tests/OnepaySignUtilTest.php
@@ -5,11 +5,11 @@ namespace Transbank\Onepay;
 use PHPUnit\Framework\TestCase;
 use Transbank\Onepay\Utils\OnepaySignUtil;
 
-require_once __DIR__ . '/mocks/TransactionCreateRequestMocks.php';
-require_once __DIR__ . '/mocks/TransactionCommitRequestMocks.php';
-require_once __DIR__ . '/mocks/ShoppingCartMocks.php';
-require_once __DIR__ . '/mocks/TransactionCreateResponseMocks.php';
-require_once __DIR__ . '/mocks/TransactionCommitResponseMocks.php';
+require_once __DIR__.'/mocks/TransactionCreateRequestMocks.php';
+require_once __DIR__.'/mocks/TransactionCommitRequestMocks.php';
+require_once __DIR__.'/mocks/ShoppingCartMocks.php';
+require_once __DIR__.'/mocks/TransactionCreateResponseMocks.php';
+require_once __DIR__.'/mocks/TransactionCommitResponseMocks.php';
 
 final class OnepaySignUtilTest extends TestCase
 {

--- a/tests/TransactionCreateRequestTest.php
+++ b/tests/TransactionCreateRequestTest.php
@@ -5,7 +5,7 @@ namespace Transbank\Onepay;
 use PHPUnit\Framework\TestCase;
 use Transbank\Onepay\Utils\OnepayRequestBuilder;
 
-require_once __DIR__ . '/mocks/ShoppingCartMocks.php';
+require_once __DIR__.'/mocks/ShoppingCartMocks.php';
 
 class TransactionCreateRequestTest extends TestCase
 {

--- a/tests/TransactionCreateRequestTest.php
+++ b/tests/TransactionCreateRequestTest.php
@@ -3,8 +3,9 @@
 namespace Transbank\Onepay;
 
 use PHPUnit\Framework\TestCase;
+use Transbank\Onepay\Utils\OnepayRequestBuilder;
 
-require_once __DIR__.'/mocks/ShoppingCartMocks.php';
+require_once __DIR__ . '/mocks/ShoppingCartMocks.php';
 
 class TransactionCreateRequestTest extends TestCase
 {
@@ -17,7 +18,7 @@ class TransactionCreateRequestTest extends TestCase
     public $optionsWithCommerceLogoUrl;
     public $optionsWithQrWidthHeightAndCommerceLogoUrl;
 
-    protected function setup()
+    protected function setup(): void
     {
         $this->emptyOptions = new Options();
         $this->optionsWithApiKey = new Options('someapikey');

--- a/tests/TransactionCreateRequestTest.php
+++ b/tests/TransactionCreateRequestTest.php
@@ -18,7 +18,7 @@ class TransactionCreateRequestTest extends TestCase
     public $optionsWithCommerceLogoUrl;
     public $optionsWithQrWidthHeightAndCommerceLogoUrl;
 
-    protected function setup(): void
+    protected function setup()
     {
         $this->emptyOptions = new Options();
         $this->optionsWithApiKey = new Options('someapikey');

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -2,12 +2,11 @@
 
 namespace Transbank\Onepay;
 
-use Exception;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__ . '/mocks/ShoppingCartMocks.php';
-require_once __DIR__ . '/mocks/TransactionCreateResponseMocks.php';
+require_once __DIR__.'/mocks/ShoppingCartMocks.php';
+require_once __DIR__.'/mocks/TransactionCreateResponseMocks.php';
 
 use Transbank\Onepay\Exceptions\SignException;
 use Transbank\Onepay\Exceptions\TransactionCommitException;
@@ -57,7 +56,7 @@ final class TransactionTest extends TestCase
     public function testTransactionRaisesWhenResponseIsNotOk()
     {
         $mockResponse = json_encode([
-            'responseCode' => 'INVALID_PARAMS',
+            'responseCode'                          => 'INVALID_PARAMS',
             'description'                           => 'Parametros invalidos',
             'result'                                => null,
         ]);
@@ -140,8 +139,8 @@ final class TransactionTest extends TestCase
         $this->assertNull($nullApiKey);
         $this->assertNull($nullSharedSecret);
 
-        putenv('ONEPAY_API_KEY=' . $originalApiKey);
-        putenv('ONEPAY_SHARED_SECRET=' . $originalSharedSecret);
+        putenv('ONEPAY_API_KEY='.$originalApiKey);
+        putenv('ONEPAY_SHARED_SECRET='.$originalSharedSecret);
 
         $this->assertEquals(OnepayBase::getApiKey(), getenv('ONEPAY_API_KEY'));
         $this->assertEquals(OnepayBase::getSharedSecret(), getenv('ONEPAY_SHARED_SECRET'));
@@ -256,7 +255,7 @@ final class TransactionTest extends TestCase
     public function testTransactionCommitRaisesWhenResponseIsNotOk()
     {
         $mockResponse = json_encode([
-            'responseCode' => 'INVALID_PARAMS',
+            'responseCode'                          => 'INVALID_PARAMS',
             'description'                           => 'Parametros invalidos',
             'result'                                => null,
         ]);

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -17,7 +17,7 @@ final class TransactionTest extends TestCase
     const EXTERNAL_UNIQUE_NUMBER_TO_COMMIT_TRANSACTION_TEST = '1532376544050';
     const OCC_TO_COMMIT_TRANSACTION_TEST = '1807829988419927';
 
-    protected function setup(): void
+    protected function setup()
     {
         OnepayBase::setSharedSecret('P4DCPS55QB2QLT56SQH6#W#LV76IAPYX');
         OnepayBase::setApiKey('mUc0GxYGor6X8u-_oB3e-HWJulRG01WoC96-_tUA3Bg');

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -2,11 +2,13 @@
 
 namespace Transbank\Onepay;
 
+use Exception;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__.'/mocks/ShoppingCartMocks.php';
-require_once __DIR__.'/mocks/TransactionCreateResponseMocks.php';
+require_once __DIR__ . '/mocks/ShoppingCartMocks.php';
+require_once __DIR__ . '/mocks/TransactionCreateResponseMocks.php';
+
 use Transbank\Onepay\Exceptions\SignException;
 use Transbank\Onepay\Exceptions\TransactionCommitException;
 use Transbank\Onepay\Exceptions\TransactionCreateException;
@@ -16,7 +18,7 @@ final class TransactionTest extends TestCase
     const EXTERNAL_UNIQUE_NUMBER_TO_COMMIT_TRANSACTION_TEST = '1532376544050';
     const OCC_TO_COMMIT_TRANSACTION_TEST = '1807829988419927';
 
-    protected function setup()
+    protected function setup(): void
     {
         OnepayBase::setSharedSecret('P4DCPS55QB2QLT56SQH6#W#LV76IAPYX');
         OnepayBase::setApiKey('mUc0GxYGor6X8u-_oB3e-HWJulRG01WoC96-_tUA3Bg');
@@ -54,9 +56,11 @@ final class TransactionTest extends TestCase
 
     public function testTransactionRaisesWhenResponseIsNotOk()
     {
-        $mockResponse = json_encode(['responseCode' => 'INVALID_PARAMS',
+        $mockResponse = json_encode([
+            'responseCode' => 'INVALID_PARAMS',
             'description'                           => 'Parametros invalidos',
-            'result'                                => null, ]);
+            'result'                                => null,
+        ]);
 
         // Create a mock http client that will return Null
         $httpClientStub = $this->getMock(HttpClient::class, ['post']);
@@ -136,8 +140,8 @@ final class TransactionTest extends TestCase
         $this->assertNull($nullApiKey);
         $this->assertNull($nullSharedSecret);
 
-        putenv('ONEPAY_API_KEY='.$originalApiKey);
-        putenv('ONEPAY_SHARED_SECRET='.$originalSharedSecret);
+        putenv('ONEPAY_API_KEY=' . $originalApiKey);
+        putenv('ONEPAY_SHARED_SECRET=' . $originalSharedSecret);
 
         $this->assertEquals(OnepayBase::getApiKey(), getenv('ONEPAY_API_KEY'));
         $this->assertEquals(OnepayBase::getSharedSecret(), getenv('ONEPAY_SHARED_SECRET'));
@@ -251,9 +255,11 @@ final class TransactionTest extends TestCase
 
     public function testTransactionCommitRaisesWhenResponseIsNotOk()
     {
-        $mockResponse = json_encode(['responseCode' => 'INVALID_PARAMS',
+        $mockResponse = json_encode([
+            'responseCode' => 'INVALID_PARAMS',
             'description'                           => 'Parametros invalidos',
-            'result'                                => null, ]);
+            'result'                                => null,
+        ]);
         // Create a mock http client that will return Null
         $httpClientStub = $this->getMock(HttpClient::class, ['post']);
         $httpClientStub->expects($this->any())->method('post')->willReturn(new Response(200, [], $mockResponse));

--- a/tests/mocks/TransactionCommitRequestMocks.php
+++ b/tests/mocks/TransactionCommitRequestMocks.php
@@ -2,6 +2,8 @@
 
 namespace Transbank\Onepay;
 
+use Transbank\Onepay\Utils\OnepayRequestBuilder;
+
 class TransactionCommitRequestMocks
 {
     public static $transactionCommitRequestMocks = [];
@@ -11,11 +13,11 @@ class TransactionCommitRequestMocks
         if (empty(self::$transactionCommitRequestMocks)) {
             $cart = ShoppingCartMocks::get();
             $transactionCommitRequest = OnepayRequestBuilder::getInstance()
-                                        ->buildCommitRequest(
-                                            '1807419329781765',
-                                            '8934751b-aa9a-45be-b686-1f45b6c45b02',
-                                            null
-                                        );
+                ->buildCommitRequest(
+                    '1807419329781765',
+                    '8934751b-aa9a-45be-b686-1f45b6c45b02',
+                    null
+                );
             array_push(self::$transactionCommitRequestMocks, $transactionCommitRequest);
         }
 

--- a/tests/mocks/TransactionCreateRequestMocks.php
+++ b/tests/mocks/TransactionCreateRequestMocks.php
@@ -4,7 +4,7 @@ namespace Transbank\Onepay;
 
 use Transbank\Onepay\Utils\OnepayRequestBuilder;
 
-require_once __DIR__ . '/ShoppingCartMocks.php';
+require_once __DIR__.'/ShoppingCartMocks.php';
 
 class TransactionCreateRequestMocks
 {

--- a/tests/mocks/TransactionCreateRequestMocks.php
+++ b/tests/mocks/TransactionCreateRequestMocks.php
@@ -2,7 +2,9 @@
 
 namespace Transbank\Onepay;
 
-require_once __DIR__.'/ShoppingCartMocks.php';
+use Transbank\Onepay\Utils\OnepayRequestBuilder;
+
+require_once __DIR__ . '/ShoppingCartMocks.php';
 
 class TransactionCreateRequestMocks
 {


### PR DESCRIPTION
Este PR modifica las clases 

  - src/Onepay/Utils/OnepaySignUtil.php
  - src/Onepay/Utils/OnepayRequestBuilder.php

Para reparar el error de Composer:

```sh
Generating optimized autoload files
Class Transbank\Onepay\OnepaySignUtil located in ./vendor/transbank/transbank-sdk/src/Onepay/Utils/OnepaySignUtil.php does not comply with psr-4 autoloading standard. Skipping.
Class Transbank\Onepay\OnepayRequestBuilder located in ./vendor/transbank/transbank-sdk/src/Onepay/Utils/OnepayRequestBuilder.php does not comply with psr-4 autoloading standard. Skipping.
```

Para esto se cambia el namespace de esas dos clases obedeciendo [la especificación de facto PSR4](https://www.php-fig.org/psr/psr-4/): Sección 3.2

> The contiguous sub-namespace names after the “namespace prefix” correspond to a subdirectory
> within a “base directory”, in which **the namespace separators represent directory separators**. 
> The subdirectory name **MUST match the case of the sub-namespace names**.

Esto es: 
 - `src/Onepay/Utils/OnepaySignUtil.php` ya no contiene la clase  `Transbank\Onepay\OnepaySignUtil` sino `Transbank\Onepay\Utils\OnepaySignUtil` 
 - `src/Onepay/Utils/OnepayRequestBuilder.php` ya no contiene la clase  `Transbank\Onepay\OnepayRequestBuilder` sino `Transbank\Onepay\Utils\OnepayRequestBuilder` 
 - todas las clases que referencian a las dos anteriores fueron modificadas para referenciar el nuevo namespace mediante `use`.
 - todas las clases que las dos anteriores utilizan del namespace `Transbank\Onepay` ya no comparten namespace y por lo mismo son referenciadas con `use`.
 - los tests que hacían uso de las dos susodichas fueron corregidos (siempre con `use`)

