### PR TITLE
WIP: Run PHPUnit on Github Actions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,9 +1,6 @@
 name: PHPUnit
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     branches:
       - master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,13 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extensions: ${{ env.PHP_EXTENSIONS }}
         key: ${{ env.key }}
+        tools: composer-v2
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
+        tools: composer:v2
+        coverage: none
       env:
         runner: ubuntu-latest # Specify the runner.
     - name: Get composer cache directory


### PR DESCRIPTION
_No mergear todavía_

No estoy seguro si hay una razón más de fondo para usar Travis, pero si lo importante es correr phpunit en varias versiones de PHP es más rápido hacerlo en Github Actions, y abre la puerta a incorporar otros checks que se pueden reflejar como comentarios en los PR ([cs2pr](https://github.com/staabm/annotate-pull-request-from-checkstyle)) como [psalm](https://psalm.dev/docs/), [phpstan](http://phpstan.org/) o [rector](https://github.com/rectorphp/rector/)

