### PR TITLE
Prepare release 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,28 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.0-beta] - 2020-12-21
+## [2.0] - 2021-04-13
+- Se elimina el uso de métodos estáticos, en reemplazo del manejo de instancias de cada clase, para mejorar el testing e implementar un mejor patrón de diseño del código. Más detalles [aquí](https://github.com/TransbankDevelopers/transbank-sdk-php/pull/182)
+- Se separa clase de Webpay Plus Mall. Ahora existe `WebpayPlus\Transaction` y `WebpayPlus\MallTransaction`
+- Se mejoran los tests internos del código.
+- Al no usar clases estáticas, permite mejorar la implementación de tests dentro del código donde se use, simulando el API de Transbank sin realizar las llamadas realmente (Mock)
+- Todos los métodos apuntan a la versión 1.2 del API de Transbank, por lo que ahora las redirecciones de vuelta en el returnUrl serán por GET en vez de POST.
+- Se mejoran los namespaces de las clases de Respuesta que devuelen los métodos.
+- Se optimiza y ordena mejor el código internamente.
+- Se aplica _coding style_ de StyleCI en todo el repositorio.
+- Se eliminan y dependencias relacionadas a la API SOAP de Transbank.
+- Se añade soporte para el producto "Webpay Modal".
+- Los productos que devuelven transacciones del tipo Mall, ahora cada detalle es un objeto `TransactionDetail` en vez de un array.
+- Se crea interfaz que permite cambiar la implementación del HttpClient, en caso de no querer utilizar Guzzle.
+- Se renombra en todos lados de `getStatus` a solo `status` en los métodos de los productos.
+- Ahora cada método si falla, llama a su propia excepción. Todas las excepciones relacionadas con unn falló en algún método y que el API responda con un error, heredan de la clase `WebpayRequestException`.
+- Ahora las excepciones contienen el detalle del request que se envió para poder "debugear" de mejor forma.
+- Ahora cada excepción devuelve el mensaje de error más ordenado, con el detalle de la respuesta del API de Transbank.
+- Se añade imagen al readme del proyecto [PR 184](https://github.com/TransbankDevelopers/transbank-sdk-php/pull/184)
+- Se deja de dar soporte a PHP 5.6.
+
+
+## [2.0-beta] - 2021-04-05
 - Se elimina el uso de métodos estáticos, en reemplazo de el manejo de instancias de cada clase, para mejorar el testing e implementar un mejor patrón de diseño del código. Más detalles [aquí](https://github.com/TransbankDevelopers/transbank-sdk-php/pull/182)
 - Se separa clase de Webpay Plus Mall. Ahora existe `WebpayPlus\Transaction` y `WebpayPlus\MallTransaction` 
 - Se mejoran los tests internos del código. 


### PR DESCRIPTION
- Se elimina el uso de métodos estáticos, en reemplazo del manejo de instancias de cada clase, para mejorar el testing e implementar un mejor patrón de diseño del código. Más detalles [aquí](https://github.com/TransbankDevelopers/transbank-sdk-php/pull/182)
- Se separa clase de Webpay Plus Mall. Ahora existe `WebpayPlus\Transaction` y `WebpayPlus\MallTransaction`
- Se mejoran los tests internos del código.
- Al no usar clases estáticas, permite mejorar la implementación de tests dentro del código donde se use, simulando el API de Transbank sin realizar las llamadas realmente (Mock)
- Todos los métodos apuntan a la versión 1.2 del API de Transbank, por lo que ahora las redirecciones de vuelta en el returnUrl serán por GET en vez de POST.
- Se mejoran los namespaces de las clases de Respuesta que devuelen los métodos.
- Se optimiza y ordena mejor el código internamente.
- Se aplica _coding style_ de StyleCI en todo el repositorio.
- Se eliminan y dependencias relacionadas a la API SOAP de Transbank.
- Se añade soporte para el producto "Webpay Modal".
- Los productos que devuelven transacciones del tipo Mall, ahora cada detalle es un objeto `TransactionDetail` en vez de un array.
- Se crea interfaz que permite cambiar la implementación del HttpClient, en caso de no querer utilizar Guzzle.
- Se renombra en todos lados de `getStatus` a solo `status` en los métodos de los productos.
- Ahora cada método si falla, llama a su propia excepción. Todas las excepciones relacionadas con unn falló en algún método y que el API responda con un error, heredan de la clase `WebpayRequestException`.
- Ahora las excepciones contienen el detalle del request que se envió para poder "debugear" de mejor forma.
- Ahora cada excepción devuelve el mensaje de error más ordenado, con el detalle de la respuesta del API de Transbank.
- Se añade imagen al readme del proyecto [PR 184](https://github.com/TransbankDevelopers/transbank-sdk-php/pull/184)
- Se deja de dar soporte a PHP 5.6.