### PR TITLE
Mostly typos and phpdocs fixes

### DIFF
--- a/src/Onepay/BaseRequest.php
+++ b/src/Onepay/BaseRequest.php
@@ -15,7 +15,6 @@ class BaseRequest
     {
         $this->apiKey = null;
         $this->appKey = null;
-        $this->generateOttQrCode = true;
     }
 
     public function getApiKey()

--- a/src/Onepay/BaseRequest.php
+++ b/src/Onepay/BaseRequest.php
@@ -2,40 +2,43 @@
 
 namespace Transbank\Onepay;
 
- /**
-  * @class BaseRequest
-  * Basic request class that includes commonly used members
-  */
- class BaseRequest
- {
-     public function __construct()
-     {
-         $this->apiKey = null;
-         $this->appKey = null;
-         $this->generateOttQrCode = true;
-     }
+/**
+ * @class BaseRequest
+ * Basic request class that includes commonly used members
+ */
+class BaseRequest
+{
+    private $apiKey;
+    private $appKey;
 
-     public function getApiKey()
-     {
-         return $this->apiKey;
-     }
+    public function __construct()
+    {
+        $this->apiKey = null;
+        $this->appKey = null;
+        $this->generateOttQrCode = true;
+    }
 
-     public function setApiKey($apiKey)
-     {
-         $this->apiKey = $apiKey;
+    public function getApiKey()
+    {
+        return $this->apiKey;
+    }
 
-         return $this;
-     }
+    public function setApiKey($apiKey)
+    {
+        $this->apiKey = $apiKey;
 
-     public function getAppKey()
-     {
-         return $this->appKey;
-     }
+        return $this;
+    }
 
-     public function setAppKey($appKey)
-     {
-         $this->appKey = $appKey;
+    public function getAppKey()
+    {
+        return $this->appKey;
+    }
 
-         return $this;
-     }
- }
+    public function setAppKey($appKey)
+    {
+        $this->appKey = $appKey;
+
+        return $this;
+    }
+}

--- a/src/Onepay/BaseResponse.php
+++ b/src/Onepay/BaseResponse.php
@@ -2,39 +2,41 @@
 
 namespace Transbank\Onepay;
 
- /**
-  * @class BaseResponse
-  * Basic response class that includes commonly used members
-  */
- class BaseResponse
- {
-     public function __construct()
-     {
-         $this->responseCode = null;
-         $this->description = null;
-     }
+/**
+ * @class BaseResponse
+ * Basic response class that includes commonly used members
+ */
+class BaseResponse
+{
+    private $responseCode;
+    private $description;
+    public function __construct()
+    {
+        $this->responseCode = null;
+        $this->description = null;
+    }
 
-     public function getResponseCode()
-     {
-         return $this->responseCode;
-     }
+    public function getResponseCode()
+    {
+        return $this->responseCode;
+    }
 
-     public function setResponseCode($responseCode)
-     {
-         $this->responseCode = $responseCode;
+    public function setResponseCode($responseCode)
+    {
+        $this->responseCode = $responseCode;
 
-         return $this;
-     }
+        return $this;
+    }
 
-     public function getDescription()
-     {
-         return $this->description;
-     }
+    public function getDescription()
+    {
+        return $this->description;
+    }
 
-     public function setDescription($appKey)
-     {
-         $this->description = $appKey;
+    public function setDescription($appKey)
+    {
+        $this->description = $appKey;
 
-         return $this;
-     }
- }
+        return $this;
+    }
+}

--- a/src/Onepay/BaseResponse.php
+++ b/src/Onepay/BaseResponse.php
@@ -10,6 +10,7 @@ class BaseResponse
 {
     private $responseCode;
     private $description;
+
     public function __construct()
     {
         $this->responseCode = null;

--- a/src/Onepay/Exceptions/SignException.php
+++ b/src/Onepay/Exceptions/SignException.php
@@ -12,6 +12,6 @@ namespace Transbank\Onepay\Exceptions;
 
      public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
      {
-         parent::_construct($message, $code, $previous);
+         parent::__construct($message, $code, $previous);
      }
  }

--- a/src/Onepay/Exceptions/SignException.php
+++ b/src/Onepay/Exceptions/SignException.php
@@ -10,7 +10,7 @@ namespace Transbank\Onepay\Exceptions;
  {
      const DEFAULT_MESSAGE = 'Signature does not match';
 
-     public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
+     public function __construct($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
      {
          parent::__construct($message, $code, $previous);
      }

--- a/src/Onepay/Exceptions/TransactionCommitException.php
+++ b/src/Onepay/Exceptions/TransactionCommitException.php
@@ -10,7 +10,7 @@ namespace Transbank\Onepay\Exceptions;
  {
      const DEFAULT_MESSAGE = 'Error when commiting Transaction. Please verify the given parameters.';
 
-     public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
+     public function __construct($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
      {
          parent::__construct($message, $code, $previous);
      }

--- a/src/Onepay/Exceptions/TransactionCommitException.php
+++ b/src/Onepay/Exceptions/TransactionCommitException.php
@@ -12,6 +12,6 @@ namespace Transbank\Onepay\Exceptions;
 
      public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
      {
-         parent::_construct($message, $code, $previous);
+         parent::__construct($message, $code, $previous);
      }
  }

--- a/src/Onepay/Exceptions/TransactionCreateException.php
+++ b/src/Onepay/Exceptions/TransactionCreateException.php
@@ -2,16 +2,16 @@
 
 namespace Transbank\Onepay\Exceptions;
 
- /**
-  * class TransactionCreateException
-  * Raised when giving invalid params to a TransactionCreateRequest.
-  */
- class TransactionCreateException extends TransbankException
- {
-     const DEFAULT_MESSAGE = 'Transaction could not be created. Please verify given parameters';
+/**
+ * class TransactionCreateException
+ * Raised when giving invalid params to a TransactionCreateRequest.
+ */
+class TransactionCreateException extends TransbankException
+{
+    const DEFAULT_MESSAGE = 'Transaction could not be created. Please verify given parameters';
 
-     public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
-     {
-         parent::_construct($message, $code, $previous);
-     }
- }
+    public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Onepay/Exceptions/TransactionCreateException.php
+++ b/src/Onepay/Exceptions/TransactionCreateException.php
@@ -10,7 +10,7 @@ class TransactionCreateException extends TransbankException
 {
     const DEFAULT_MESSAGE = 'Transaction could not be created. Please verify given parameters';
 
-    public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
+    public function __construct($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Onepay/Exceptions/TransbankException.php
+++ b/src/Onepay/Exceptions/TransbankException.php
@@ -13,6 +13,6 @@ namespace Transbank\Onepay\Exceptions;
 
      public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
      {
-         parent::_construct($message, $code, $previous);
+         parent::__construct($message, $code, $previous);
      }
  }

--- a/src/Onepay/Exceptions/TransbankException.php
+++ b/src/Onepay/Exceptions/TransbankException.php
@@ -11,7 +11,7 @@ namespace Transbank\Onepay\Exceptions;
  {
      const DEFAULT_MESSAGE = 'An error has happened, verify given parameters and try again.';
 
-     public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
+     public function __construct($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
      {
          parent::__construct($message, $code, $previous);
      }

--- a/src/Onepay/OnepayBase.php
+++ b/src/Onepay/OnepayBase.php
@@ -11,7 +11,7 @@ class OnepayBase
     const DEFAULT_CALLBACK = 'http://no.callback.has/been.set';
 
     public static $appKeys = [
-        'TEST' => '1a0c0639-bd2f-4846-8d26-81f43187e797',
+        'TEST'                       => '1a0c0639-bd2f-4846-8d26-81f43187e797',
         'LIVE'                       => '2B571C49-C1B6-4AD1-9806-592AC68023B7',
         'MOCK'                       => '04533c31-fe7e-43ed-bbc4-1c8ab1538afp',
     ];
@@ -69,7 +69,7 @@ class OnepayBase
     public static function integrationTypes($type = null)
     {
         $types = [
-            'TEST' => 'https://onepay.ionix.cl',
+            'TEST'       => 'https://onepay.ionix.cl',
             'LIVE'       => 'https://www.onepay.cl',
             'MOCK'       => 'https://transbank-onepay-ewallet-mock.herokuapp.com',
         ];
@@ -77,7 +77,7 @@ class OnepayBase
         if (!$type) {
             return $types;
         } elseif (!$types[$type]) {
-            throw new \Exception('Invalid type, valid types: ' . join(', ', array_keys($types)));
+            throw new \Exception('Invalid type, valid types: '.join(', ', array_keys($types)));
         } else {
             return $types[$type];
         }
@@ -174,7 +174,7 @@ class OnepayBase
             $integrationTypes = array_keys(self::integrationTypes());
             $integrationTypesAsString = join(', ', $integrationTypes);
 
-            throw new \Exception('Invalid integration type, valid values are: ' . $integrationTypesAsString);
+            throw new \Exception('Invalid integration type, valid values are: '.$integrationTypesAsString);
         }
 
         return $url;
@@ -197,7 +197,7 @@ class OnepayBase
             $integrationTypes = array_keys(self::integrationTypes());
             $integrationTypesAsString = join(', ', $integrationTypes);
 
-            throw new \Exception('Invalid integration type, valid values are: ' . $integrationTypesAsString);
+            throw new \Exception('Invalid integration type, valid values are: '.$integrationTypesAsString);
         }
         self::$integrationType = $type;
     }

--- a/src/Onepay/OnepayBase.php
+++ b/src/Onepay/OnepayBase.php
@@ -10,9 +10,11 @@ class OnepayBase
 {
     const DEFAULT_CALLBACK = 'http://no.callback.has/been.set';
 
-    public static $appKeys = ['TEST' => '1a0c0639-bd2f-4846-8d26-81f43187e797',
+    public static $appKeys = [
+        'TEST' => '1a0c0639-bd2f-4846-8d26-81f43187e797',
         'LIVE'                       => '2B571C49-C1B6-4AD1-9806-592AC68023B7',
-        'MOCK'                       => '04533c31-fe7e-43ed-bbc4-1c8ab1538afp', ];
+        'MOCK'                       => '04533c31-fe7e-43ed-bbc4-1c8ab1538afp',
+    ];
     public static $callbackUrl = null;
 
     public static $serverBasePath;
@@ -66,14 +68,16 @@ class OnepayBase
 
     public static function integrationTypes($type = null)
     {
-        $types = ['TEST' => 'https://onepay.ionix.cl',
+        $types = [
+            'TEST' => 'https://onepay.ionix.cl',
             'LIVE'       => 'https://www.onepay.cl',
-            'MOCK'       => 'https://transbank-onepay-ewallet-mock.herokuapp.com', ];
+            'MOCK'       => 'https://transbank-onepay-ewallet-mock.herokuapp.com',
+        ];
 
         if (!$type) {
             return $types;
         } elseif (!$types[$type]) {
-            throw new \Exception('Invalid type, valid types: '.join(array_keys($types), ', '));
+            throw new \Exception('Invalid type, valid types: ' . join(', ', array_keys($types)));
         } else {
             return $types[$type];
         }
@@ -168,9 +172,9 @@ class OnepayBase
         $url = self::integrationTypes()[$type];
         if (!$url) {
             $integrationTypes = array_keys(self::integrationTypes());
-            $integrationTypesAsString = join($integrationTypes, ', ');
+            $integrationTypesAsString = join(', ', $integrationTypes);
 
-            throw new \Exception('Invalid integration type, valid values are: '.$integrationTypesAsString);
+            throw new \Exception('Invalid integration type, valid values are: ' . $integrationTypesAsString);
         }
 
         return $url;
@@ -191,9 +195,9 @@ class OnepayBase
     {
         if (!self::integrationTypes()[$type]) {
             $integrationTypes = array_keys(self::integrationTypes());
-            $integrationTypesAsString = join($integrationTypes, ', ');
+            $integrationTypesAsString = join(', ', $integrationTypes);
 
-            throw new \Exception('Invalid integration type, valid values are: '.$integrationTypesAsString);
+            throw new \Exception('Invalid integration type, valid values are: ' . $integrationTypesAsString);
         }
         self::$integrationType = $type;
     }

--- a/src/Onepay/TransactionCreateRequest.php
+++ b/src/Onepay/TransactionCreateRequest.php
@@ -33,6 +33,8 @@ class TransactionCreateRequest extends BaseRequest implements \JsonSerializable
         $widthHeight = '',
         $commerceLogoUrl = ''
     ) {
+        $this->generateOttQrCode = true;
+
         if (!$externalUniqueNumber) {
             throw new \Exception('External unique number cannot be null.');
         }

--- a/src/Onepay/TransactionCreateRequest.php
+++ b/src/Onepay/TransactionCreateRequest.php
@@ -18,6 +18,8 @@ class TransactionCreateRequest extends BaseRequest implements \JsonSerializable
     private $signature; // String
     private $generateOttQrCode = true;
     private $commerceLogoUrl;
+    private $issuedAt;
+    private $widthHeight;
 
     public function __construct(
         $externalUniqueNumber,

--- a/src/Patpass/PatpassByWebpay.php
+++ b/src/Patpass/PatpassByWebpay.php
@@ -2,6 +2,8 @@
 
 namespace Transbank\Patpass;
 
+use Transbank\Webpay\Options;
+
 use Transbank\Utils\EnvironmentManager;
 
 class PatpassByWebpay extends EnvironmentManager
@@ -14,5 +16,9 @@ class PatpassByWebpay extends EnvironmentManager
     public static function configureForTesting()
     {
         self::configureForIntegration(static::DEFAULT_COMMERCE_CODE, static::DEFAULT_API_KEY);
+    }
+    public static function getDefaultOptions()
+    {
+        return Options::forIntegration(static::DEFAULT_COMMERCE_CODE, static::DEFAULT_API_KEY);
     }
 }

--- a/src/Patpass/PatpassByWebpay.php
+++ b/src/Patpass/PatpassByWebpay.php
@@ -2,7 +2,6 @@
 
 namespace Transbank\Patpass;
 
-
 use Transbank\Utils\EnvironmentManager;
 
 class PatpassByWebpay extends EnvironmentManager
@@ -16,6 +15,7 @@ class PatpassByWebpay extends EnvironmentManager
     {
         self::configureForIntegration(static::DEFAULT_COMMERCE_CODE, static::DEFAULT_API_KEY);
     }
+
     public static function getDefaultOptions()
     {
         return Options::forIntegration(static::DEFAULT_COMMERCE_CODE, static::DEFAULT_API_KEY);

--- a/src/Patpass/PatpassByWebpay.php
+++ b/src/Patpass/PatpassByWebpay.php
@@ -2,7 +2,6 @@
 
 namespace Transbank\Patpass;
 
-use Transbank\Webpay\Options;
 
 use Transbank\Utils\EnvironmentManager;
 

--- a/src/Patpass/PatpassByWebpay/Transaction.php
+++ b/src/Patpass/PatpassByWebpay/Transaction.php
@@ -2,6 +2,7 @@
 
 namespace Transbank\Patpass\PatpassByWebpay;
 
+use Transbank\Patpass\Options;
 use Transbank\Patpass\PatpassByWebpay;
 use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionCommitException;
 use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionCreateException;
@@ -11,7 +12,6 @@ use Transbank\Patpass\PatpassByWebpay\Responses\TransactionCreateResponse;
 use Transbank\Patpass\PatpassByWebpay\Responses\TransactionStatusResponse;
 use Transbank\Utils\InteractsWithWebpayApi;
 use Transbank\Webpay\Exceptions\WebpayRequestException;
-use Transbank\Patpass\Options;
 
 class Transaction
 {
@@ -70,6 +70,7 @@ class Transaction
 
         return new TransactionStatusResponse($response);
     }
+
     /**
      * Get the default options if none are given.
      *
@@ -79,7 +80,8 @@ class Transaction
     {
         return PatpassByWebpay::getOptions();
     }
-    public static  function getDefaultOptions()
+
+    public static function getDefaultOptions()
     {
         return PatpassByWebpay::getDefaultOptions();
     }

--- a/src/Patpass/PatpassByWebpay/Transaction.php
+++ b/src/Patpass/PatpassByWebpay/Transaction.php
@@ -2,6 +2,7 @@
 
 namespace Transbank\Patpass\PatpassByWebpay;
 
+use Transbank\Patpass\PatpassByWebpay as PatpassByWebpayMain;
 use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionCommitException;
 use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionCreateException;
 use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionStatusException;
@@ -10,6 +11,7 @@ use Transbank\Patpass\PatpassByWebpay\Responses\TransactionCreateResponse;
 use Transbank\Patpass\PatpassByWebpay\Responses\TransactionStatusResponse;
 use Transbank\Utils\InteractsWithWebpayApi;
 use Transbank\Webpay\Exceptions\WebpayRequestException;
+use Transbank\Patpass\Options;
 
 class Transaction
 {
@@ -67,5 +69,18 @@ class Transaction
         }
 
         return new TransactionStatusResponse($response);
+    }
+    /**
+     * Get the default options if none are given.
+     *
+     * @return Options|null
+     */
+    public static function getGlobalOptions()
+    {
+        return PatpassByWebpayMain::getOptions();
+    }
+    public static  function getDefaultOptions()
+    {
+        return PatpassByWebpayMain::getDefaultOptions();
     }
 }

--- a/src/Patpass/PatpassByWebpay/Transaction.php
+++ b/src/Patpass/PatpassByWebpay/Transaction.php
@@ -2,7 +2,7 @@
 
 namespace Transbank\Patpass\PatpassByWebpay;
 
-use Transbank\Patpass\PatpassByWebpay as PatpassByWebpayMain;
+use Transbank\Patpass\PatpassByWebpay;
 use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionCommitException;
 use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionCreateException;
 use Transbank\Patpass\PatpassByWebpay\Exceptions\TransactionStatusException;
@@ -77,10 +77,10 @@ class Transaction
      */
     public static function getGlobalOptions()
     {
-        return PatpassByWebpayMain::getOptions();
+        return PatpassByWebpay::getOptions();
     }
     public static  function getDefaultOptions()
     {
-        return PatpassByWebpayMain::getDefaultOptions();
+        return PatpassByWebpay::getDefaultOptions();
     }
 }

--- a/src/Utils/ConfiguresEnvironment.php
+++ b/src/Utils/ConfiguresEnvironment.php
@@ -9,7 +9,6 @@ use Transbank\Webpay\Options;
  */
 trait ConfiguresEnvironment
 {
-
     /**
      * @param $commerceCode
      * @param string $apiKey

--- a/src/Utils/ConfiguresEnvironment.php
+++ b/src/Utils/ConfiguresEnvironment.php
@@ -9,13 +9,6 @@ use Transbank\Webpay\Options;
  */
 trait ConfiguresEnvironment
 {
-    /**
-     * @return string
-     */
-    public static function getIntegrationType()
-    {
-        return static::$integrationType;
-    }
 
     /**
      * @param $commerceCode

--- a/src/Utils/HasTransactionStatus.php
+++ b/src/Utils/HasTransactionStatus.php
@@ -2,8 +2,6 @@
 
 namespace Transbank\Utils;
 
-use Transbank\Webpay\WebpayPlus\Responses\TransactionStatusResponse;
-
 trait HasTransactionStatus
 {
     public $status;

--- a/src/Utils/HasTransactionStatus.php
+++ b/src/Utils/HasTransactionStatus.php
@@ -24,7 +24,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $amount
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setAmount($amount)
     {
@@ -36,7 +36,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $buyOrder
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setBuyOrder($buyOrder)
     {
@@ -64,7 +64,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $cardNumber
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setCardNumber($cardNumber)
     {
@@ -100,7 +100,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $status
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setStatus($status)
     {
@@ -112,7 +112,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $sessionId
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setSessionId($sessionId)
     {
@@ -124,7 +124,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $paymentTypeCode
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setPaymentTypeCode($paymentTypeCode)
     {
@@ -136,7 +136,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $installmentsAmount
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setInstallmentsAmount($installmentsAmount)
     {
@@ -148,7 +148,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $accountingDate
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setAccountingDate($accountingDate)
     {
@@ -168,7 +168,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $responseCode
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setResponseCode($responseCode)
     {
@@ -225,7 +225,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $transactionDate
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setTransactionDate($transactionDate)
     {
@@ -277,7 +277,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $installmentsNumber
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setInstallmentsNumber($installmentsNumber)
     {
@@ -297,7 +297,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $balance
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setBalance($balance)
     {
@@ -309,7 +309,7 @@ trait HasTransactionStatus
     /**
      * @param mixed $authorizationCode
      *
-     * @return TransactionStatusResponse
+     * @return static
      */
     public function setAuthorizationCode($authorizationCode)
     {

--- a/src/Utils/HttpClient.php
+++ b/src/Utils/HttpClient.php
@@ -30,7 +30,7 @@ class HttpClient implements HttpClientInterface
 
         $baseHeaders = [
             'Content-Type' => 'application/json',
-            'User-Agent'   => 'SDK-PHP/'.$installedVersion,
+            'User-Agent'   => 'SDK-PHP/' . $installedVersion,
         ];
 
         $givenHeaders = isset($options['headers']) ? $options['headers'] : [];
@@ -73,7 +73,7 @@ class HttpClient implements HttpClientInterface
      * @param $method
      * @param $url
      * @param array $headers
-     * @param array $payload
+     * @param string|null $payload
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
      *

--- a/src/Utils/HttpClient.php
+++ b/src/Utils/HttpClient.php
@@ -30,7 +30,7 @@ class HttpClient implements HttpClientInterface
 
         $baseHeaders = [
             'Content-Type' => 'application/json',
-            'User-Agent'   => 'SDK-PHP/' . $installedVersion,
+            'User-Agent'   => 'SDK-PHP/'.$installedVersion,
         ];
 
         $givenHeaders = isset($options['headers']) ? $options['headers'] : [];
@@ -72,7 +72,7 @@ class HttpClient implements HttpClientInterface
     /**
      * @param $method
      * @param $url
-     * @param array $headers
+     * @param array       $headers
      * @param string|null $payload
      *
      * @throws \GuzzleHttp\Exception\GuzzleException

--- a/src/Utils/InteractsWithWebpayApi.php
+++ b/src/Utils/InteractsWithWebpayApi.php
@@ -39,7 +39,7 @@ trait InteractsWithWebpayApi
     /**
      * @param $method
      * @param $endpoint
-     * @param array $payload
+     * @param array|null $payload
      *
      * @throws WebpayRequestException
      *

--- a/src/Webpay/Exceptions/TransbankException.php
+++ b/src/Webpay/Exceptions/TransbankException.php
@@ -8,6 +8,6 @@ class TransbankException extends \Exception
 
     public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
     {
-        parent::_construct($message, $code, $previous);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Webpay/Exceptions/TransbankException.php
+++ b/src/Webpay/Exceptions/TransbankException.php
@@ -6,7 +6,7 @@ class TransbankException extends \Exception
 {
     const DEFAULT_MESSAGE = 'An error has happened, verify given parameters and try again.';
 
-    public function __construc($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
+    public function __construct($message = self::DEFAULT_MESSAGE, $code = 0, $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Webpay/Oneclick/Responses/MallTransactionCaptureResponse.php
+++ b/src/Webpay/Oneclick/Responses/MallTransactionCaptureResponse.php
@@ -55,12 +55,12 @@ class MallTransactionCaptureResponse
 
     public function getResponseCode()
     {
-        return $this->reponseCode;
+        return $this->responseCode;
     }
 
-    public function setResponseCode($reponseCode)
+    public function setResponseCode($responseCode)
     {
-        $this->reponseCode = $reponseCode;
+        $this->responseCode = $responseCode;
 
         return $this;
     }

--- a/src/Webpay/WebpayPlus/MallTransaction.php
+++ b/src/Webpay/WebpayPlus/MallTransaction.php
@@ -197,7 +197,7 @@ class MallTransaction
     /**
      * Get the default options if none are given.
      *
-     * @return Options
+     * @return Options|null
      */
     public static function getGlobalOptions()
     {

--- a/src/Webpay/WebpayPlus/Transaction.php
+++ b/src/Webpay/WebpayPlus/Transaction.php
@@ -175,7 +175,7 @@ class Transaction
     /**
      * Get the default options if none are given.
      *
-     * @return Options
+     * @return Options|null
      */
     public static function getGlobalOptions()
     {


### PR DESCRIPTION
Corrí [Psalm](https://psalm.dev/docs/) sobre el repo para verificar si #212 se manifestaba en alguna sintaxis incompatible con PHP 7.0, pero me encontré con cosas mucho más mundanas y a continuación enumero cuáles fueron y cómo las solucioné lo mejor que pude:

**1. Errores de tecleo . (__construc y _construct con un solo underscore)**

https://github.com/TransbankDevelopers/transbank-sdk-php/blob/ee6e2e4b8b9d36e0f49353cae73fba505909c2fe/src/Webpay/Exceptions/TransbankException.php#L9-L12

Me limité a corregir nada más.
 _________

_________

**2. propiedades no declaradas, que en general se definen en el constructor**

https://github.com/TransbankDevelopers/transbank-sdk-php/blob/8201fa4c17bf51312a4053db9947c2c96f4e7395/src/Onepay/BaseRequest.php#L9-L16

https://github.com/TransbankDevelopers/transbank-sdk-php/blob/8201fa4c17bf51312a4053db9947c2c96f4e7395/src/Onepay/BaseResponse.php#L9-L16

No es tajantemente un error, pero sí es frágil si una clase extiende de ella y sobreescribe el constructor omitiendo esas propiedades. Las declaré como privadas dado que las clases tienen getters y setters.

_________

_________

**3. parámetros traspuestos al usar `join` (el array a implotar debe ser el segundo parámetro)**

https://github.com/TransbankDevelopers/transbank-sdk-php/blob/8201fa4c17bf51312a4053db9947c2c96f4e7395/src/Onepay/OnepayBase.php#L170-L171

Los puse en el orden correcto
_________

_________

**4. Clase padre referencia propiedad privada definida en una clase hija**

`BaseRequest` no tiene la propiedad `generateOttQrCode`

https://github.com/TransbankDevelopers/transbank-sdk-php/blob/8201fa4c17bf51312a4053db9947c2c96f4e7395/src/Onepay/BaseRequest.php#L11-L16 

Lo cual sería irrelevante excepto porque la propiedad sí existe en su clase hija `TransactionCreateRequest` y es privada:

https://github.com/TransbankDevelopers/transbank-sdk-php/blob/8201fa4c17bf51312a4053db9947c2c96f4e7395/src/Onepay/TransactionCreateRequest.php#L19

No es un error, formalmente, salvo porque la clase hija nunca asignará esa propiedad, y desde la clase padre no se puede. Invocar `parent::__construct()` desde `TransactionCreateRequest` diría: `PHP Fatal error:  Uncaught Error: Cannot access private property...`

En este PR   asigné la propiedad en el constructor de la clase hija, pero no estoy seguro si eso es lo que corresponde como regla de negocio.


_________

_________

**5. Acceso a métodos y propiedades estáticas indefinidas en un trait**

El trait `ConfiguresEnvironment` alude a la propiedad estática `$integrationType`. 

https://github.com/TransbankDevelopers/transbank-sdk-php/blob/8201fa4c17bf51312a4053db9947c2c96f4e7395/src/Utils/ConfiguresEnvironment.php#L15-L18

Pero esa propiedad no existe en ninguna clase que use aquel trait. Lo mismo pasa en casos donde los traits invocan los métodos estático `getGlobalOptions` o `getDefaultOptions`, pero éstos no existen en algunos casos.

Para lo primero simplemente quité ese método luego de verificar que no se invoca sobre clases que usan el trait.

Para lo segundo, declaré los métodos en `Transbank\Patpass\PatpassByWebpay\Transaction`, y este es el supuesto más débil, sólo asumí un paralelismo con los otros usos de esos métodos, de modo que delega a   `Transbank\Patpass\PatpassByWebpay` y sus opciones son de tipo `Transbank\Patpass\Options`.
_________

_________

**6. (esto es insignificante) tipos incorrectos en DocBlocks**

Por ejemplo el trait `HasTransactionStatus` tiene muchos métodos fluent (retornan `$this`). Lo correcto es que el docblock declare que retorna `static`, pero hoy dice que retorna específicamente `Transbank\Webpay\WebpayPlus\Responses\TransactionStatusResponse`:


https://github.com/TransbankDevelopers/transbank-sdk-php/blob/8201fa4c17bf51312a4053db9947c2c96f4e7395/src/Utils/HasTransactionStatus.php#L24-L34

Sólo corregí los tipos donde correspondía.
