### PR TITLE
Fix typo that is not compatible with PHP 7.0

### DIFF
--- a/src/Webpay/Oneclick/MallInscription.php
+++ b/src/Webpay/Oneclick/MallInscription.php
@@ -89,7 +89,7 @@ class MallInscription
             $this->sendRequest(
                 'DELETE',
                 static::INSCRIPTION_DELETE_ENDPOINT,
-                $payload,
+                $payload
             );
         } catch (WebpayRequestException $e) {
             if ($e->getHttpCode() !== 204) {


### PR DESCRIPTION
Fix typo that is not compatible with PHP 7.0

In PHP 7.0 you can not have a trailing comma when calling methods. 

![image](https://user-images.githubusercontent.com/1103494/124651564-1595c000-de69-11eb-8034-b964c2427c01.png)
