### PR TITLE
Fixing SonarCloud Issues

### DIFF
--- a/tests/Mocks/TransactionCommitRequestMocks.php
+++ b/tests/Mocks/TransactionCommitRequestMocks.php
@@ -11,7 +11,6 @@ class TransactionCommitRequestMocks
     public static function transactionCreateRequestMocks()
     {
         if (empty(self::$transactionCommitRequestMocks)) {
-            $cart = ShoppingCartMocks::get();
             $transactionCommitRequest = OnepayRequestBuilder::getInstance()
                 ->buildCommitRequest(
                     '1807419329781765',

--- a/tests/Mocks/TransactionCommitRequestMocks.php
+++ b/tests/Mocks/TransactionCommitRequestMocks.php
@@ -11,6 +11,7 @@ class TransactionCommitRequestMocks
     public static function transactionCreateRequestMocks()
     {
         if (empty(self::$transactionCommitRequestMocks)) {
+            ShoppingCartMocks::get();
             $transactionCommitRequest = OnepayRequestBuilder::getInstance()
                 ->buildCommitRequest(
                     '1807419329781765',

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -9,9 +9,9 @@ class OptionsTest extends TestCase
     public function it_assign_contructor_params_to_their_corresponding_properties()
     {
         $options = new Options('a', 'b', 'c');
-        $this->assertSame($options->getApiKey(), 'a');
-        $this->assertSame($options->getCommerceCode(), 'b');
-        $this->assertSame($options->getIntegrationType(), 'c');
+        $this->assertSame('a', $options->getApiKey());
+        $this->assertSame('b', $options->getCommerceCode());
+        $this->assertSame('c', $options->getIntegrationType());
     }
 
     /** @test */

--- a/tests/RequestServiceTest.php
+++ b/tests/RequestServiceTest.php
@@ -23,23 +23,16 @@ class RequestServiceTest extends TestCase
         $httpClientMock
             ->expects($this->once())
             ->method('request')
-            ->with($this->anything(), $this->anything(), $this->anything(), $this->equalTo([
-                'headers' => $expectedHeaders,
-            ]))
+            ->with($this->anything(), $this->anything(), $this->anything(), $this->equalTo(['headers' => $expectedHeaders,]))
             ->willReturn(
-                new Response(200, [], json_encode([
-                    'token' => 'mock',
-                    'url'   => 'http://mock.cl/',
-                ]))
+                new Response(200, [], json_encode(['token' => 'mock', 'url'   => 'https://mock.cl/',]))
             );
-
-        $request = (new HttpClientRequestService($httpClientMock))->request('POST', '/transactions', [], $optionsMock);
     }
 
     /** @test */
     public function it_uses_the_base_url_provided_by_the_given_options()
     {
-        $expectedBaseUrl = 'http://mock.mock/';
+        $expectedBaseUrl = 'https://mock.mock/';
         $endpoint = '/transactions';
 
         $optionsMock = $this->createMock(Options::class);
@@ -52,15 +45,9 @@ class RequestServiceTest extends TestCase
         $httpClientMock
             ->expects($this->once())
             ->method('request')
-            ->with($this->anything(), $expectedBaseUrl.$endpoint, $this->anything())
+            ->with($this->anything(), $expectedBaseUrl . $endpoint, $this->anything())
             ->willReturn(
-                new Response(200, [], json_encode([
-                    'token' => 'mock',
-                    'url'   => 'http://mock.cl/',
-                ]))
+                new Response(200, [], json_encode(['token' => 'mock', 'url'   => 'https://mock.cl/',]))
             );
-
-        $request = (new HttpClientRequestService($httpClientMock))
-            ->request('POST', $endpoint, [], $optionsMock);
     }
 }

--- a/tests/RequestServiceTest.php
+++ b/tests/RequestServiceTest.php
@@ -27,6 +27,7 @@ class RequestServiceTest extends TestCase
             ->willReturn(
                 new Response(200, [], json_encode(['token' => 'mock', 'url'   => 'https://mock.cl/',]))
             );
+        (new HttpClientRequestService($httpClientMock))->request('POST', '/transactions', [], $optionsMock);
     }
 
     /** @test */
@@ -49,5 +50,6 @@ class RequestServiceTest extends TestCase
             ->willReturn(
                 new Response(200, [], json_encode(['token' => 'mock', 'url'   => 'https://mock.cl/',]))
             );
+        (new HttpClientRequestService($httpClientMock))->request('POST', $endpoint, [], $optionsMock);
     }
 }

--- a/tests/Webpay/Modal/TransbankWebpayModalTest.php
+++ b/tests/Webpay/Modal/TransbankWebpayModalTest.php
@@ -30,6 +30,7 @@ class TransbankWebpayModalTest extends \PHPUnit\Framework\TestCase
     public function it_fails_when_creates_a_modal_transaction_with_invalid_data()
     {
         $this->expectException(TransactionCreateException::class);
+        (new Transaction())->create('hola', '');
     }
 
     /** @test */
@@ -46,6 +47,7 @@ class TransbankWebpayModalTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(TransactionCreateException::class, 'Not Authorized');
         $transaction = new Transaction(Options::forIntegration('commerceCode', 'fakeApiKey'));
+        $transaction->create(1500, 'BuyOrder1', 'Session2312');
     }
 
     /** @test */

--- a/tests/Webpay/Modal/TransbankWebpayModalTest.php
+++ b/tests/Webpay/Modal/TransbankWebpayModalTest.php
@@ -30,7 +30,6 @@ class TransbankWebpayModalTest extends \PHPUnit\Framework\TestCase
     public function it_fails_when_creates_a_modal_transaction_with_invalid_data()
     {
         $this->expectException(TransactionCreateException::class);
-        $response = (new Transaction())->create('hola', '');
     }
 
     /** @test */
@@ -39,7 +38,7 @@ class TransbankWebpayModalTest extends \PHPUnit\Framework\TestCase
         $response = (new Transaction())->create(1500, 'BuyOrder1', 'Session2312');
         $status = Transaction::build()->status($response->getToken());
         $this->assertInstanceOf(TransactionStatusResponse::class, $status);
-        $this->assertEquals($status->getStatus(), 'INITIALIZED');
+        $this->assertEquals('INITIALIZED', $status->getStatus());
     }
 
     /** @test */
@@ -47,7 +46,6 @@ class TransbankWebpayModalTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(TransactionCreateException::class, 'Not Authorized');
         $transaction = new Transaction(Options::forIntegration('commerceCode', 'fakeApiKey'));
-        $response = $transaction->create(1500, 'BuyOrder1', 'Session2312');
     }
 
     /** @test */

--- a/tests/Webpay/OneClick/TransbankOneclickTest.php
+++ b/tests/Webpay/OneClick/TransbankOneclickTest.php
@@ -115,8 +115,8 @@ class TransbankOneclickTest extends TestCase
 
     protected function createDemoData()
     {
-        $this->username = 'demo_'.rand(100000, 999999);
-        $this->email = 'demo_'.rand(100000, 999999).'@demo.cl';
+        $this->username = 'demo_' . rand(100000, 999999);
+        $this->email = 'demo_' . rand(100000, 999999) . '@demo.cl';
         $this->responseUrl = 'http://demo.cl/return';
     }
 }

--- a/tests/Webpay/TransaccionCompleta/TransaccionCompletaTest.php
+++ b/tests/Webpay/TransaccionCompleta/TransaccionCompletaTest.php
@@ -73,9 +73,9 @@ class TransaccionCompletaTest extends TestCase
     protected function setUp(): void
     {
         $this->amount = 1000;
-        $this->sessionId = 'some_session_id_'.uniqid();
+        $this->sessionId = 'some_session_id_' . uniqid();
         $this->buyOrder = '123999555';
-        $this->mockBaseUrl = 'http://mockurl.cl';
+        $this->mockBaseUrl = 'https://mockurl.cl';
         $this->cvv = '123';
         $this->cardNumber = '4051885600446623';
         $this->cardExpiration = '12/24';
@@ -174,9 +174,9 @@ class TransaccionCompletaTest extends TestCase
         $transaction = new Transaction($this->optionsMock, $this->requestServiceMock);
         $response = $transaction->installments($tokenMock, 2);
         $this->assertInstanceOf(TransactionInstallmentsResponse::class, $response);
-        $this->assertEquals($response->getInstallmentsAmount(), 1000);
-        $this->assertEquals($response->getIdQueryInstallments(), 33189687);
-        $this->assertEquals($response->getDeferredPeriods(), []);
+        $this->assertEquals(1000, $response->getInstallmentsAmount());
+        $this->assertEquals(33189687, $response->getIdQueryInstallments());
+        $this->assertEquals([], $response->getDeferredPeriods());
     }
 
     /** @test */
@@ -214,19 +214,19 @@ class TransaccionCompletaTest extends TestCase
         $transaction = new Transaction($this->optionsMock, $this->requestServiceMock);
         $response = $transaction->commit($tokenMock);
         $this->assertInstanceOf(TransactionCommitResponse::class, $response);
-        $this->assertSame($response->getVci(), null);
-        $this->assertSame($response->getSessionId(), 'sesion1234564');
-        $this->assertSame($response->getStatus(), 'AUTHORIZED');
-        $this->assertSame($response->getAmount(), 10000);
-        $this->assertSame($response->getBuyOrder(), 'OrdenCompra55886');
-        $this->assertSame($response->getCardNumber(), '6623');
-        $this->assertSame($response->getCardDetail(), ['card_number' => '6623']);
-        $this->assertSame($response->getAuthorizationCode(), '1213');
-        $this->assertSame($response->getPaymentTypeCode(), 'NC');
-        $this->assertSame($response->getInstallmentsNumber(), 10);
-        $this->assertSame($response->getInstallmentsAmount(), 1000);
-        $this->assertSame($response->getTransactionDate(), '2021-03-29T06:33:32.954Z');
-        $this->assertSame($response->getAccountingDate(), '0329');
+        $this->assertSame(null, $response->getVci());
+        $this->assertSame('sesion1234564', $response->getSessionId());
+        $this->assertSame('AUTHORIZED', $response->getStatus());
+        $this->assertSame(10000, $response->getAmount());
+        $this->assertSame('OrdenCompra55886', $response->getBuyOrder());
+        $this->assertSame('6623', $response->getCardNumber());
+        $this->assertSame(['card_number' => '6623'], $response->getCardDetail());
+        $this->assertSame('1213', $response->getAuthorizationCode());
+        $this->assertSame('NC', $response->getPaymentTypeCode());
+        $this->assertSame(10, $response->getInstallmentsNumber());
+        $this->assertSame(1000, $response->getInstallmentsAmount());
+        $this->assertSame('2021-03-29T06:33:32.954Z', $response->getTransactionDate());
+        $this->assertSame('0329', $response->getAccountingDate());
     }
 
     /** @test */
@@ -264,19 +264,19 @@ class TransaccionCompletaTest extends TestCase
         $transaction = new Transaction($this->optionsMock, $this->requestServiceMock);
         $response = $transaction->status($tokenMock);
         $this->assertInstanceOf(TransactionStatusResponse::class, $response);
-        $this->assertSame($response->getVci(), null);
-        $this->assertSame($response->getSessionId(), 'sesion1234564');
-        $this->assertSame($response->getStatus(), 'AUTHORIZED');
-        $this->assertSame($response->getAmount(), 10000);
-        $this->assertSame($response->getBuyOrder(), 'OrdenCompra55886');
-        $this->assertSame($response->getCardNumber(), '6623');
-        $this->assertSame($response->getCardDetail(), ['card_number' => '6623']);
-        $this->assertSame($response->getAuthorizationCode(), '1213');
-        $this->assertSame($response->getPaymentTypeCode(), 'NC');
-        $this->assertSame($response->getInstallmentsNumber(), 10);
-        $this->assertSame($response->getInstallmentsAmount(), 1000);
-        $this->assertSame($response->getTransactionDate(), '2021-03-29T06:33:32.954Z');
-        $this->assertSame($response->getAccountingDate(), '0329');
+        $this->assertSame(null, $response->getVci());
+        $this->assertSame('sesion1234564', $response->getSessionId());
+        $this->assertSame('AUTHORIZED', $response->getStatus());
+        $this->assertSame(10000, $response->getAmount());
+        $this->assertSame('OrdenCompra55886', $response->getBuyOrder());
+        $this->assertSame('6623', $response->getCardNumber());
+        $this->assertSame(['card_number' => '6623'], $response->getCardDetail());
+        $this->assertSame('1213', $response->getAuthorizationCode());
+        $this->assertSame('NC', $response->getPaymentTypeCode());
+        $this->assertSame(10, $response->getInstallmentsNumber());
+        $this->assertSame(1000, $response->getInstallmentsAmount());
+        $this->assertSame('2021-03-29T06:33:32.954Z', $response->getTransactionDate());
+        $this->assertSame('0329', $response->getAccountingDate());
     }
 
     /*

--- a/tests/Webpay/WebpayPlus/WebpayMallTransactionTest.php
+++ b/tests/Webpay/WebpayPlus/WebpayMallTransactionTest.php
@@ -65,10 +65,10 @@ class WebpayMallTransactionTest extends TestCase
     protected function setUp(): void
     {
         $this->amount = 1000;
-        $this->sessionId = 'some_session_id_'.uniqid();
+        $this->sessionId = 'some_session_id_' . uniqid();
         $this->buyOrder = '123999555';
         $this->returnUrl = 'https://comercio.cl/callbacks/transaccion_finalizada';
-        $this->mockBaseUrl = 'http://mockurl.cl';
+        $this->mockBaseUrl = 'https://mockurl.cl';
     }
 
     /** @test */
@@ -132,7 +132,7 @@ class WebpayMallTransactionTest extends TestCase
             ->willReturn(
                 [
                     'token' => $tokenMock,
-                    'url'   => 'http://mock.cl/',
+                    'url'   => 'https://mock.cl/',
                 ]
             );
 
@@ -140,7 +140,7 @@ class WebpayMallTransactionTest extends TestCase
         $response = $transaction->create($this->buyOrder, $this->sessionId, $this->returnUrl, $details);
         $this->assertInstanceOf(MallTransactionCreateResponse::class, $response);
         $this->assertEquals($response->getToken(), $tokenMock);
-        $this->assertEquals($response->getUrl(), 'http://mock.cl/');
+        $this->assertEquals('https://mock.cl/', $response->getUrl());
     }
 
     /** @test */
@@ -199,31 +199,31 @@ class WebpayMallTransactionTest extends TestCase
         $secondDetail = $response->getDetails()[1];
         $this->assertNotNull($firstDetail);
         $this->assertNotNull($secondDetail);
-        $this->assertSame($response->getVci(), 'TSY');
-        $this->assertSame($response->getSessionId(), 'session1234564');
-        $this->assertSame($response->getBuyOrder(), 'OrdenCompra36271');
-        $this->assertSame($response->getCardNumber(), '6623');
-        $this->assertSame($response->getCardDetail(), ['card_number' => '6623']);
-        $this->assertSame($response->getAccountingDate(), '0329');
-        $this->assertSame($response->getTransactionDate(), '2021-03-29T04:47:19.885Z');
-        $this->assertSame($firstDetail->getResponseCode(), 0);
-        $this->assertSame($firstDetail->getStatus(), 'AUTHORIZED');
-        $this->assertSame($firstDetail->getAmount(), 1000);
-        $this->assertSame($firstDetail->getAuthorizationCode(), '1213');
-        $this->assertSame($firstDetail->getPaymentTypeCode(), 'VN');
-        $this->assertSame($firstDetail->getInstallmentsNumber(), 0);
-        $this->assertSame($firstDetail->getInstallmentsAmount(), null);
-        $this->assertSame($firstDetail->getCommerceCode(), '597055555536');
-        $this->assertSame($firstDetail->getBuyOrder(), 'OrdenCompraChild_66986_1');
-        $this->assertSame($secondDetail->getResponseCode(), 0);
-        $this->assertSame($secondDetail->getStatus(), 'AUTHORIZED');
-        $this->assertSame($secondDetail->getAmount(), 2000);
-        $this->assertSame($secondDetail->getAuthorizationCode(), '1213');
-        $this->assertSame($secondDetail->getPaymentTypeCode(), 'VN');
-        $this->assertSame($secondDetail->getInstallmentsNumber(), 0);
-        $this->assertSame($secondDetail->getInstallmentsAmount(), null);
-        $this->assertSame($secondDetail->getCommerceCode(), '597055555537');
-        $this->assertSame($secondDetail->getBuyOrder(), 'OrdenCompraChild_66986_2');
+        $this->assertSame('TSY', $response->getVci());
+        $this->assertSame('session1234564', $response->getSessionId());
+        $this->assertSame('OrdenCompra36271', $response->getBuyOrder());
+        $this->assertSame('6623', $response->getCardNumber());
+        $this->assertSame(['card_number' => '6623'], $response->getCardDetail());
+        $this->assertSame('0329', $response->getAccountingDate());
+        $this->assertSame('2021-03-29T04:47:19.885Z', $response->getTransactionDate());
+        $this->assertSame(0, $firstDetail->getResponseCode());
+        $this->assertSame('AUTHORIZED', $firstDetail->getStatus());
+        $this->assertSame(1000, $firstDetail->getAmount());
+        $this->assertSame('1213', $firstDetail->getAuthorizationCode());
+        $this->assertSame('VN', $firstDetail->getPaymentTypeCode());
+        $this->assertSame(0, $firstDetail->getInstallmentsNumber());
+        $this->assertSame(null, $firstDetail->getInstallmentsAmount());
+        $this->assertSame('597055555536', $firstDetail->getCommerceCode());
+        $this->assertSame('OrdenCompraChild_66986_1', $firstDetail->getBuyOrder());
+        $this->assertSame(0, $secondDetail->getResponseCode());
+        $this->assertSame('AUTHORIZED', $secondDetail->getStatus());
+        $this->assertSame(2000, $secondDetail->getAmount());
+        $this->assertSame('1213', $secondDetail->getAuthorizationCode());
+        $this->assertSame('VN', $secondDetail->getPaymentTypeCode());
+        $this->assertSame(0, $secondDetail->getInstallmentsNumber());
+        $this->assertSame(null, $secondDetail->getInstallmentsAmount());
+        $this->assertSame('597055555537', $secondDetail->getCommerceCode());
+        $this->assertSame('OrdenCompraChild_66986_2', $secondDetail->getBuyOrder());
     }
 
     /*

--- a/tests/Webpay/WebpayPlus/WebpayPlusTransactionTest.php
+++ b/tests/Webpay/WebpayPlus/WebpayPlusTransactionTest.php
@@ -67,7 +67,7 @@ class WebpayPlusTransactionTest extends TestCase
         $this->sessionId = 'some_session_id_'.uniqid();
         $this->buyOrder = '123999555';
         $this->returnUrl = 'https://comercio.cl/callbacks/transaccion_finalizada';
-        $this->mockBaseUrl = 'http://mockurl.cl';
+        $this->mockBaseUrl = 'https://mockurl.cl';
     }
 
     /** @test */
@@ -106,7 +106,7 @@ class WebpayPlusTransactionTest extends TestCase
         $requestServiceMock->expects($this->once())->method('request')->willReturn(
             [
                 'token' => 'mock',
-                'url'   => 'http://mock.cl/',
+                'url'   => 'https://mock.cl/',
             ]
         );
 
@@ -135,7 +135,7 @@ class WebpayPlusTransactionTest extends TestCase
             ->willReturn(
                 [
                     'token' => $tokenMock,
-                    'url'   => 'http://mock.cl/',
+                    'url'   => 'https://mock.cl/',
                 ]
             );
 
@@ -143,7 +143,7 @@ class WebpayPlusTransactionTest extends TestCase
         $response = $transaction->create($this->buyOrder, $this->sessionId, $this->amount, $this->returnUrl);
         $this->assertInstanceOf(TransactionCreateResponse::class, $response);
         $this->assertEquals($response->getToken(), $tokenMock);
-        $this->assertEquals($response->getUrl(), 'http://mock.cl/');
+        $this->assertEquals($response->getUrl(), 'https://mock.cl/');
     }
 
     /** @test */

--- a/tests/Webpay/WebpayPlus/WebpayPlusWithoutMocksTest.php
+++ b/tests/Webpay/WebpayPlus/WebpayPlusWithoutMocksTest.php
@@ -34,7 +34,7 @@ class WebpayPlusWithoutMocksTest extends TestCase
         $this->sessionId = 'some_session_id_'.uniqid();
         $this->buyOrder = '123999555';
         $this->returnUrl = 'https://comercio.cl/callbacks/transaccion_creada_exitosamente';
-        $this->mockBaseUrl = 'http://mockurl.cl';
+        $this->mockBaseUrl = 'https://mockurl.cl';
     }
 
     /** @test */


### PR DESCRIPTION
Fixing files to mitigate coding smells and security hotspots, there are different changes, but all of them are very little
Example: change https for http, change positions on arguments, delete unused variables.