### PR TITLE
fix: repair incomplete responses

### DIFF
--- a/src/TransaccionCompleta/Responses/MallTransactionCommitResponse.php
+++ b/src/TransaccionCompleta/Responses/MallTransactionCommitResponse.php
@@ -4,4 +4,11 @@ namespace Transbank\TransaccionCompleta\Responses;
 
 class MallTransactionCommitResponse extends MallTransactionStatusResponse
 {
+  public function __construct($json)
+    {
+      parent::__construct($json);
+      foreach ($this->details as $index => $detail) {
+        unset($this->details[$index]->balance);
+      }
+    }
 }

--- a/src/TransaccionCompleta/Responses/TransactionCommitResponse.php
+++ b/src/TransaccionCompleta/Responses/TransactionCommitResponse.php
@@ -4,4 +4,9 @@ namespace Transbank\TransaccionCompleta\Responses;
 
 class TransactionCommitResponse extends TransactionStatusResponse
 {
+    public function __construct($json)
+    {
+        parent::__construct($json);
+        unset($this->balance);
+    }
 }

--- a/src/TransaccionCompleta/Responses/TransactionDetail.php
+++ b/src/TransaccionCompleta/Responses/TransactionDetail.php
@@ -2,6 +2,18 @@
 
 namespace Transbank\TransaccionCompleta\Responses;
 
+use Transbank\Utils\Utils;
+
 class TransactionDetail extends \Transbank\Webpay\WebpayPlus\Responses\TransactionDetail
 {
+    public $prepaidBalance;
+
+    public static function createFromArray(array $array)
+    {
+        $result = parent::createFromArray($array);
+        $result->prepaidBalance = Utils::returnValueIfExists($array, 'prepaid_balance');
+
+
+        return $result;
+    }
 }

--- a/src/TransaccionCompleta/Responses/TransactionDetail.php
+++ b/src/TransaccionCompleta/Responses/TransactionDetail.php
@@ -10,10 +10,37 @@ class TransactionDetail extends \Transbank\Webpay\WebpayPlus\Responses\Transacti
 
     public static function createFromArray(array $array)
     {
-        $result = parent::createFromArray($array);
+        $result = new TransactionDetail();
+        $result->amount = Utils::returnValueIfExists($array, 'amount');
+        $result->status = Utils::returnValueIfExists($array, 'status');
+        $result->authorizationCode = Utils::returnValueIfExists($array, 'authorization_code');
+        $result->paymentTypeCode = Utils::returnValueIfExists($array, 'payment_type_code');
+        $result->responseCode = Utils::returnValueIfExists($array, 'response_code');
+        $result->installmentsNumber = Utils::returnValueIfExists($array, 'installments_number');
+        $result->installmentsAmount = Utils::returnValueIfExists($array, 'installments_amount');
+        $result->commerceCode = Utils::returnValueIfExists($array, 'commerce_code');
+        $result->buyOrder = Utils::returnValueIfExists($array, 'buy_order');
+        $result->balance = Utils::returnValueIfExists($array, 'balance');
         $result->prepaidBalance = Utils::returnValueIfExists($array, 'prepaid_balance');
-
 
         return $result;
     }
+
+    /**
+     * @return mixed
+     */
+    public function getPrepaidBalance()
+    {
+        return $this->prepaidBalance;
+    }
+
+    /**
+     * @param mixed $balance
+     */
+    public function setPrepaidBalance($prepaidBalance)
+    {
+        $this->prepaidBalance = $prepaidBalance;
+    }
+
+
 }

--- a/src/TransaccionCompleta/Responses/TransactionStatusResponse.php
+++ b/src/TransaccionCompleta/Responses/TransactionStatusResponse.php
@@ -10,11 +10,13 @@ class TransactionStatusResponse
     use HasTransactionStatus;
 
     public $vci;
+    public $prepaidBalance;
 
     public function __construct($json)
     {
         $this->vci = Utils::returnValueIfExists($json, 'vci');
         $this->setTransactionStatusFields($json);
+        $this->prepaidBalance = Utils::returnValueIfExists($json, 'prepaid_balance');
     }
 
     /**
@@ -33,6 +35,25 @@ class TransactionStatusResponse
     public function setVci($vci)
     {
         $this->vci = $vci;
+
+        return $this;
+    }
+     /**
+     * @return mixed
+     */
+    public function getPrepaidBalance()
+    {
+        return $this->prepaidBalance;
+    }
+
+    /**
+     * @param mixed $prepaidBalance
+     *
+     * @return TransactionStatusResponse
+     */
+    public function setPrepaidBalance($prepaidBalance)
+    {
+        $this->prepaidBalance = $prepaidBalance;
 
         return $this;
     }

--- a/src/Webpay/Oneclick/Responses/MallTransactionAuthorizeResponse.php
+++ b/src/Webpay/Oneclick/Responses/MallTransactionAuthorizeResponse.php
@@ -4,4 +4,11 @@ namespace Transbank\Webpay\Oneclick\Responses;
 
 class MallTransactionAuthorizeResponse extends MallTransactionStatusResponse
 {
+  public function __construct($json)
+    {
+      parent::__construct($json);
+      foreach ($this->details as $index => $detail) {
+        unset($this->details[$index]->balance);
+      }
+    }
 }

--- a/src/Webpay/Oneclick/Responses/MallTransactionStatusResponse.php
+++ b/src/Webpay/Oneclick/Responses/MallTransactionStatusResponse.php
@@ -7,9 +7,7 @@ use Transbank\Utils\Utils;
 class MallTransactionStatusResponse
 {
     public $buyOrder;
-    public $sessionId;
     public $cardNumber;
-    public $expirationDate;
     public $accountingDate;
     public $transactionDate;
 
@@ -21,8 +19,6 @@ class MallTransactionStatusResponse
     public function __construct($json)
     {
         $this->buyOrder = Utils::returnValueIfExists($json, 'buy_order');
-        $this->sessionId = Utils::returnValueIfExists($json, 'session_id');
-        $this->expirationDate = Utils::returnValueIfExists($json, 'expiration_date');
         $this->accountingDate = Utils::returnValueIfExists($json, 'accounting_date');
         $this->transactionDate = Utils::returnValueIfExists($json, 'transaction_date');
         $cardDetail = Utils::returnValueIfExists($json, 'card_detail');

--- a/src/Webpay/WebpayPlus/Responses/TransactionDetail.php
+++ b/src/Webpay/WebpayPlus/Responses/TransactionDetail.php
@@ -197,4 +197,20 @@ class TransactionDetail
     {
         $this->installmentsAmount = $installmentsAmount;
     }
+
+    /**
+     * @return mixed
+     */
+    public function getBalance()
+    {
+        return $this->balance;
+    }
+
+    /**
+     * @param mixed $balance
+     */
+    public function setBalance($balance)
+    {
+        $this->balance = $balance;
+    }
 }

--- a/src/Webpay/WebpayPlus/Responses/TransactionDetail.php
+++ b/src/Webpay/WebpayPlus/Responses/TransactionDetail.php
@@ -17,6 +17,7 @@ class TransactionDetail
     public $installmentsAmount;
     public $commerceCode;
     public $buyOrder;
+    public $balance;
 
     public static function createFromArray(array $array)
     {
@@ -30,6 +31,7 @@ class TransactionDetail
         $result->installmentsAmount = Utils::returnValueIfExists($array, 'installments_amount');
         $result->commerceCode = Utils::returnValueIfExists($array, 'commerce_code');
         $result->buyOrder = Utils::returnValueIfExists($array, 'buy_order');
+        $result->balance = Utils::returnValueIfExists($array, 'balance');
 
         return $result;
     }


### PR DESCRIPTION
remove fields in oneclick status transaction:
 'sessionId'
 'expirationDate' 
 
add fields 'balance, prepaid_balance' in oneclick and "transacción completa"

