### PR TITLE
feat: set request timeout

### DIFF
--- a/src/Utils/HttpClient.php
+++ b/src/Utils/HttpClient.php
@@ -45,11 +45,13 @@ class HttpClient implements HttpClientInterface
             $payload = json_encode($payload);
         }
 
+        $requestTimeout = $options['timeout'] ?? 0;
+
         if (defined('\GuzzleHttp\Client::VERSION') && version_compare(Client::VERSION, '6', '<')) {
-            return $this->sendGuzzle5Request($method, $url, $headers, $payload);
+            return $this->sendGuzzle5Request($method, $url, $headers, $payload, $requestTimeout);
         }
 
-        return $this->sendGuzzleRequest($method, $url, $headers, $payload);
+        return $this->sendGuzzleRequest($method, $url, $headers, $payload, $requestTimeout);
     }
 
     /**
@@ -62,9 +64,11 @@ class HttpClient implements HttpClientInterface
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    protected function sendGuzzle5Request($method, $url, array $headers, $payload)
+    protected function sendGuzzle5Request($method, $url, array $headers, $payload, $timeout)
     {
-        $client = new Client();
+        $client = new Client(['timeout' => $timeout,
+                            'read_timeout' => $timeout,
+                            'connect_timeout' => $timeout]);
 
         $request = $client->createRequest($method, $url, [
             'headers' => $headers,
@@ -84,11 +88,15 @@ class HttpClient implements HttpClientInterface
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    protected function sendGuzzleRequest($method, $url, array $headers, $payload)
+    protected function sendGuzzleRequest($method, $url, array $headers, $payload, $timeout)
     {
         $request = new Request($method, $url, $headers, $payload);
 
-        $client = new Client(['http_errors' => false]);
+        $client = new Client(['http_errors' => false,
+                            'timeout' => $timeout,
+                            'read_timeout' => $timeout,
+                            'connect_timeout' => $timeout],
+                        );
 
         return $client->send($request);
     }

--- a/src/Utils/HttpClientRequestService.php
+++ b/src/Utils/HttpClientRequestService.php
@@ -72,7 +72,8 @@ class HttpClientRequestService implements RequestService
         $request = new TransbankApiRequest($method, $baseUrl, $endpoint, $payload, $headers);
 
         $this->setLastRequest($request);
-        $response = $client->request($method, $baseUrl.$endpoint, $payload, ['headers' => $headers]);
+        $response = $client->request($method, $baseUrl.$endpoint, $payload, ['headers' => $headers,
+                                                                            'timeout' => $options->getTimeout()]);
 
         $this->setLastResponse($response);
         $responseStatusCode = $response->getStatusCode();

--- a/src/Webpay/Options.php
+++ b/src/Webpay/Options.php
@@ -16,6 +16,13 @@ class Options
 
     const DEFAULT_API_KEY = '579B532A7440BB0C9079DED94D31EA1615BACEB56610332264630D42D0A36B1C';
 
+    const DEFAULT_TIMEOUT = 60 * 10;
+
+    /**
+     * @var int Timeout for requests in seconds
+     */
+    protected $timeout;
+
     /**
      * @var string Your api key, given by Transbank.Sent as a header when
      *             making requests to Transbank on a field called "Tbk-Api-Key-Secret"
@@ -32,11 +39,12 @@ class Options
      */
     public $integrationType = self::ENVIRONMENT_INTEGRATION;
 
-    public function __construct($apiKey, $commerceCode, $integrationType = self::ENVIRONMENT_INTEGRATION)
+    public function __construct($apiKey, $commerceCode, $integrationType = self::ENVIRONMENT_INTEGRATION, $timeout = self::DEFAULT_TIMEOUT)
     {
         $this->apiKey = $apiKey;
         $this->commerceCode = $commerceCode;
         $this->integrationType = $integrationType;
+        $this->timeout = $timeout;
     }
 
     public static function forProduction($commerceCode, $apiKey)
@@ -136,5 +144,25 @@ class Options
             'Tbk-Api-Key-Id'     => $this->getCommerceCode(),
             'Tbk-Api-Key-Secret' => $this->getApiKey(),
         ];
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeout()
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * @param int $timeout
+     *
+     * @return Options
+     */
+    public function setTimeout($timeout)
+    {
+        $this->timeout = $timeout;
+
+        return $this;
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -8,10 +8,11 @@ class OptionsTest extends TestCase
     /** @test */
     public function it_assign_contructor_params_to_their_corresponding_properties()
     {
-        $options = new Options('a', 'b', 'c');
+        $options = new Options('a', 'b', 'c', 10);
         $this->assertSame('a', $options->getApiKey());
         $this->assertSame('b', $options->getCommerceCode());
         $this->assertSame('c', $options->getIntegrationType());
+        $this->assertSame(10, $options->getTimeout());
     }
 
     /** @test */
@@ -59,5 +60,13 @@ class OptionsTest extends TestCase
     {
         $options = Options::forIntegration('CommerceCode', 'ApiKey');
         $this->assertSame(Options::BASE_URL_INTEGRATION, $options->getApiBaseUrl());
+    }
+
+    /** @test */
+    public function it_return_default_values()
+    {
+        $options = new Options('apiKey', 'commerceCode');
+        $this->assertSame(Options::DEFAULT_INTEGRATION_TYPE, $options->getIntegrationType());
+        $this->assertSame(Options::DEFAULT_TIMEOUT, $options->getTimeout());
     }
 }

--- a/tests/RequestServiceTest.php
+++ b/tests/RequestServiceTest.php
@@ -12,18 +12,23 @@ class RequestServiceTest extends TestCase
     public function it_send_the_headers_provided_by_the_given_options()
     {
         $expectedHeaders = ['api_key' => 'commerce_code', 'api_secret' => 'fakeApiKey'];
-
+        $timeOut = 10;
         $optionsMock = $this->createMock(Options::class);
         $optionsMock
             ->expects($this->once())
             ->method('getHeaders')
             ->willReturn($expectedHeaders);
+        $optionsMock
+            ->expects($this->once())
+            ->method('getTimeout')
+            ->willReturn($timeOut);
 
         $httpClientMock = $this->createMock(HttpClient::class);
         $httpClientMock
             ->expects($this->once())
             ->method('request')
-            ->with($this->anything(), $this->anything(), $this->anything(), $this->equalTo(['headers' => $expectedHeaders,]))
+            ->with($this->anything(), $this->anything(), $this->anything(), $this->equalTo(['headers' => $expectedHeaders,
+                                                                                            'timeout' => $timeOut]))
             ->willReturn(
                 new Response(200, [], json_encode(['token' => 'mock', 'url'   => 'https://mock.cl/',]))
             );


### PR DESCRIPTION
This PR add a default timeout for requests on 10 minutes.
This can configured using an `Options` object when creating the products. The fourth parameter is a value in seconds , for example: 

`$timeOut = 20;`
`$options = new Options("commerceCode", "apiKey", Options::ENVIRONMENT_INTEGRATION, $timeOut);`
`$transaction = new Transaction($options);`

## TEST

![image](https://github.com/TransbankDevelopers/transbank-sdk-php/assets/101830551/60d8ff1e-3de6-4c1d-965c-0afc08272730)

![image](https://github.com/TransbankDevelopers/transbank-sdk-php/assets/101830551/d810161b-a2e4-4444-97c2-c752b185bbe7)


![image](https://github.com/TransbankDevelopers/transbank-sdk-php/assets/101830551/74010c81-cffe-47d5-b580-0fe63ba3f78b)

![image](https://github.com/TransbankDevelopers/transbank-sdk-php/assets/101830551/92782ab1-f4b9-4b87-b813-4f7c63df103c)

