### PR TITLE
test: fix all tests for new php version and variable typing

### DIFF
--- a/tests/Utils/HasTransactionStatusTest.php
+++ b/tests/Utils/HasTransactionStatusTest.php
@@ -39,11 +39,11 @@ class HasTransactionStatusTest extends TestCase
 
         $this->assertSame(5, $transactionStatus->getInstallmentsNumber());
 
-        $this->assertSame(100.0, $transactionStatus->getAmount());
+        $this->assertSame(100, $transactionStatus->getAmount());
 
         $this->assertSame('123', $transactionStatus->getBuyOrder());
 
-        $this->assertSame(500.00, $transactionStatus->getBalance());
+        $this->assertSame(500, $transactionStatus->getBalance());
 
         $this->assertSame('AUTHORIZED', $transactionStatus->getStatus());
 
@@ -51,7 +51,7 @@ class HasTransactionStatusTest extends TestCase
 
         $this->assertSame('VD', $transactionStatus->getPaymentTypeCode());
 
-        $this->assertSame(100.00, $transactionStatus->getInstallmentsAmount());
+        $this->assertSame(100, $transactionStatus->getInstallmentsAmount());
 
         $this->assertSame(200, $transactionStatus->getResponseCode());
 

--- a/tests/Utils/HasTransactionStatusTest.php
+++ b/tests/Utils/HasTransactionStatusTest.php
@@ -3,7 +3,8 @@
 use PHPUnit\Framework\TestCase;
 use Transbank\Utils\HasTransactionStatus;
 
-class DummyClass {
+class DummyClass
+{
     use HasTransactionStatus;
 }
 
@@ -13,17 +14,19 @@ class HasTransactionStatusTest extends TestCase
     {
 
         $date = new DateTime();
+        $accountingDateFormat = $date->format('md');
+        $transactionDateFormat = $date->format('Y-m-d\TH:i:s.v\Z');
         $json = [
-            'amount' =>100,
-            'status' =>'AUTHORIZED',
-            'buy_order' =>'123',
-            'session_id' =>'123',
+            'amount' => 100,
+            'status' => 'AUTHORIZED',
+            'buy_order' => '123',
+            'session_id' => '123',
             'card_detail' => ['card_number' => '123'],
             'card_number' => '123',
-            'accounting_date' => $date,
-            'transaction_date' => $date,
+            'accounting_date' => $accountingDateFormat,
+            'transaction_date' => $transactionDateFormat,
             'authorization_code' => '123',
-            'payment_type_code' =>'VD',
+            'payment_type_code' => 'VD',
             'response_code' => 200,
             'installments_amount' => 100,
             'installments_number' => 5,
@@ -32,15 +35,15 @@ class HasTransactionStatusTest extends TestCase
 
         $transactionStatus = new DummyClass();
         $transactionStatus->setTransactionStatusFields($json);
-        $this->assertSame($date, $transactionStatus->getTransactionDate());
+        $this->assertSame($transactionDateFormat, $transactionStatus->getTransactionDate());
 
         $this->assertSame(5, $transactionStatus->getInstallmentsNumber());
 
-        $this->assertSame(100, $transactionStatus->getAmount());
+        $this->assertSame(100.0, $transactionStatus->getAmount());
 
         $this->assertSame('123', $transactionStatus->getBuyOrder());
 
-        $this->assertSame(500, $transactionStatus->getBalance());
+        $this->assertSame(500.00, $transactionStatus->getBalance());
 
         $this->assertSame('AUTHORIZED', $transactionStatus->getStatus());
 
@@ -48,7 +51,7 @@ class HasTransactionStatusTest extends TestCase
 
         $this->assertSame('VD', $transactionStatus->getPaymentTypeCode());
 
-        $this->assertSame(100, $transactionStatus->getInstallmentsAmount());
+        $this->assertSame(100.00, $transactionStatus->getInstallmentsAmount());
 
         $this->assertSame(200, $transactionStatus->getResponseCode());
 
@@ -58,6 +61,6 @@ class HasTransactionStatusTest extends TestCase
 
         $this->assertSame('123', $transactionStatus->getCardNumber());
 
-        $this->assertSame($date, $transactionStatus->getAccountingDate());
+        $this->assertSame($accountingDateFormat, $transactionStatus->getAccountingDate());
     }
 }

--- a/tests/Webpay/OneClick/Responses/InscriptionFinishResponseTest.php
+++ b/tests/Webpay/OneClick/Responses/InscriptionFinishResponseTest.php
@@ -3,28 +3,29 @@
 use PHPUnit\Framework\TestCase;
 use Transbank\Webpay\Oneclick\Responses\InscriptionFinishResponse;
 
-class OneClickInscriptionFinishResponseTest extends TestCase {
+class OneClickInscriptionFinishResponseTest extends TestCase
+{
 
-    protected $json;
-    protected $inscriptionResponse;
+    protected array $json;
+    protected InscriptionFinishResponse $inscriptionResponse;
 
-    protected function setUp():void {
+    protected function setUp(): void
+    {
         $this->json = [
-            'response_code' => '00',
+            'response_code' => 0,
             'tbk_user' => '123456',
             'authorization_code' => '7890',
             'card_type' => 'Visa',
             'card_number' => '**** **** **** 1234'
         ];
         $this->inscriptionResponse = new InscriptionFinishResponse($this->json);
-
     }
     /** @test */
     public function it_can_be_initialized_from_json()
     {
         $response = new InscriptionFinishResponse($this->json);
 
-        $this->assertSame('00', $response->responseCode);
+        $this->assertSame(0, $response->responseCode);
         $this->assertSame('123456', $response->tbkUser);
         $this->assertSame('7890', $response->authorizationCode);
         $this->assertSame('Visa', $response->cardType);
@@ -40,7 +41,8 @@ class OneClickInscriptionFinishResponseTest extends TestCase {
     /** @test */
     public function it_returns_false_when_response_code_is_not_approved()
     {
-        $json = ['response_code' => '01'];
+        $json = $this->json;
+        $json['response_code'] = 1;
         $response = new InscriptionFinishResponse($json);
         $this->assertFalse($response->isApproved());
     }

--- a/tests/Webpay/OneClick/Responses/MallTransactionCaptureResponseTest.php
+++ b/tests/Webpay/OneClick/Responses/MallTransactionCaptureResponseTest.php
@@ -10,7 +10,7 @@ class MallTransactionCaptureResponseTest extends TestCase
         $json = [
             'authorization_code' => '123',
             'authorization_date' => '2022-01-01',
-            'captured_amount' => 100,
+            'captured_amount' => 100.00,
             'response_code' => 200,
         ];
 
@@ -18,7 +18,7 @@ class MallTransactionCaptureResponseTest extends TestCase
 
         $this->assertSame('123', $response->getAuthorizationCode());
         $this->assertSame('2022-01-01', $response->authorizationDate);
-        $this->assertSame(100, $response->capturedAmount);
+        $this->assertSame(100.00, $response->capturedAmount);
         $this->assertSame(200, $response->responseCode);
     }
 

--- a/tests/Webpay/OneClick/Responses/MallTransactionCaptureResponseTest.php
+++ b/tests/Webpay/OneClick/Responses/MallTransactionCaptureResponseTest.php
@@ -10,7 +10,7 @@ class MallTransactionCaptureResponseTest extends TestCase
         $json = [
             'authorization_code' => '123',
             'authorization_date' => '2022-01-01',
-            'captured_amount' => 100.00,
+            'captured_amount' => 100.45,
             'response_code' => 200,
         ];
 
@@ -18,7 +18,7 @@ class MallTransactionCaptureResponseTest extends TestCase
 
         $this->assertSame('123', $response->getAuthorizationCode());
         $this->assertSame('2022-01-01', $response->authorizationDate);
-        $this->assertSame(100.00, $response->capturedAmount);
+        $this->assertSame(100.45, $response->capturedAmount);
         $this->assertSame(200, $response->responseCode);
     }
 

--- a/tests/Webpay/OneClick/Responses/MallTransactionRefundResponseTest.php
+++ b/tests/Webpay/OneClick/Responses/MallTransactionRefundResponseTest.php
@@ -11,9 +11,9 @@ class OneClickMallTransactionRefundResponseTest extends TestCase
             'type' => 'testType',
             'authorization_code' => 'testAuthorizationCode',
             'authorization_date' => 'testAuthorizationDate',
-            'nullified_amount' => 'testNullifiedAmount',
-            'balance' => 'testBalance',
-            'response_code' => 'testResponseCode',
+            'nullified_amount' => 4,
+            'balance' => 2,
+            'response_code' => 0,
         ];
 
         $response = new MallTransactionRefundResponse($json);
@@ -21,22 +21,33 @@ class OneClickMallTransactionRefundResponseTest extends TestCase
         $this->assertSame('testType', $response->type);
         $this->assertSame('testAuthorizationCode', $response->authorizationCode);
         $this->assertSame('testAuthorizationDate', $response->authorizationDate);
-        $this->assertSame('testNullifiedAmount', $response->nullifiedAmount);
-        $this->assertSame('testBalance', $response->balance);
-        $this->assertSame('testResponseCode', $response->responseCode);
+        $this->assertSame(4.0, $response->nullifiedAmount);
+        $this->assertSame(2.0, $response->balance);
+        $this->assertSame(0, $response->responseCode);
     }
 
     public function testConstructorAssignsNullIfNotExists()
     {
+
         $json = [];
+        $json['type'] = 'testType';
 
         $response = new MallTransactionRefundResponse($json);
 
-        $this->assertNull($response->type);
         $this->assertNull($response->authorizationCode);
         $this->assertNull($response->authorizationDate);
         $this->assertNull($response->nullifiedAmount);
         $this->assertNull($response->balance);
         $this->assertNull($response->responseCode);
+    }
+
+    public function testConstructorThrowsTypeErrorWhenTypeIsNull()
+    {
+        $this->expectException(TypeError::class);
+
+        $json = [];
+        $response = new MallTransactionRefundResponse($json);
+
+        $this->assertNotNull($response);
     }
 }

--- a/tests/Webpay/OneClick/Responses/MallTransactionRefundResponseTest.php
+++ b/tests/Webpay/OneClick/Responses/MallTransactionRefundResponseTest.php
@@ -21,8 +21,8 @@ class OneClickMallTransactionRefundResponseTest extends TestCase
         $this->assertSame('testType', $response->type);
         $this->assertSame('testAuthorizationCode', $response->authorizationCode);
         $this->assertSame('testAuthorizationDate', $response->authorizationDate);
-        $this->assertSame(4.0, $response->nullifiedAmount);
-        $this->assertSame(2.0, $response->balance);
+        $this->assertSame(4, $response->nullifiedAmount);
+        $this->assertSame(2, $response->balance);
         $this->assertSame(0, $response->responseCode);
     }
 

--- a/tests/Webpay/OneClick/Responses/MallTransactionRefundResponseTest.php
+++ b/tests/Webpay/OneClick/Responses/MallTransactionRefundResponseTest.php
@@ -40,14 +40,4 @@ class OneClickMallTransactionRefundResponseTest extends TestCase
         $this->assertNull($response->balance);
         $this->assertNull($response->responseCode);
     }
-
-    public function testConstructorThrowsTypeErrorWhenTypeIsNull()
-    {
-        $this->expectException(TypeError::class);
-
-        $json = [];
-        $response = new MallTransactionRefundResponse($json);
-
-        $this->assertNotNull($response);
-    }
 }

--- a/tests/Webpay/TransaccionCompleta/MallTransactionStatusResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/MallTransactionStatusResponseTest.php
@@ -40,13 +40,13 @@ class MallTransactionStatusResponseTest extends TestCase
         $this->assertSame($json['card_detail']['card_number'], $response->getCardNumber());
         $jsonDetails = $response->getDetails()[0];
         $this->assertCount(1, $response->getDetails());
-        $this->assertSame(500.00, $jsonDetails->getAmount());
+        $this->assertSame(500, $jsonDetails->getAmount());
         $this->assertSame('AUTHORIZED', $jsonDetails->getStatus());
         $this->assertSame('456456', $jsonDetails->getAuthorizationCode());
         $this->assertSame('VN', $jsonDetails->getPaymentTypeCode());
         $this->assertSame(0, $jsonDetails->getResponseCode());
         $this->assertSame(1, $jsonDetails->getInstallmentsNumber());
-        $this->assertSame(500.00, $jsonDetails->getInstallmentsAmount());
+        $this->assertSame(500, $jsonDetails->getInstallmentsAmount());
         $this->assertSame('597020000540', $jsonDetails->getCommerceCode());
         $this->assertSame('567890', $jsonDetails->getBuyOrder());
     }

--- a/tests/Webpay/TransaccionCompleta/MallTransactionStatusResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/MallTransactionStatusResponseTest.php
@@ -9,24 +9,46 @@ class MallTransactionStatusResponseTest extends TestCase
     public function testConstructor()
     {
         $json = [
-            'buyOrder' => '123456',
-            'accounting_date' => '2022-01-01',
+            'buy_order' => '123456',
+            'accounting_date' => '0622',
             'transaction_date' => '2022-01-01 12:00:00',
             'card_detail' => ['card_number' => '1234567890123456'],
             'details' => [
-                ['detail_key1' => 'detail_value1'],
-                ['detail_key2' => 'detail_value2']
+                [
+                    'amount' => 500,
+                    'status' => 'AUTHORIZED',
+                    'authorization_code' => '456456',
+                    'payment_type_code' => 'VN',
+                    'response_code' => 0,
+                    'installments_number' => 1,
+                    'installments_amount' => 500,
+                    'commerce_code' => '597020000540',
+                    'buy_order' => '567890',
+                    'balance' => 0,
+                    'detail_key1' => 'detail_value1',
+                    'detail_key2' => 'detail_value2'
+                ]
             ],
         ];
 
         $response = new MallTransactionStatusResponse($json);
 
-        $this->assertSame($json['buyOrder'], $response->getBuyOrder());
+        $this->assertSame($json['buy_order'], $response->getBuyOrder());
         $this->assertSame($json['accounting_date'], $response->getAccountingDate());
         $this->assertSame($json['transaction_date'], $response->getTransactionDate());
         $this->assertSame($json['card_detail'], $response->getCardDetail());
         $this->assertSame($json['card_detail']['card_number'], $response->getCardNumber());
-        $this->assertCount(2, $response->getDetails());
+        $jsonDetails = $response->getDetails()[0];
+        $this->assertCount(1, $response->getDetails());
+        $this->assertSame(500.00, $jsonDetails->getAmount());
+        $this->assertSame('AUTHORIZED', $jsonDetails->getStatus());
+        $this->assertSame('456456', $jsonDetails->getAuthorizationCode());
+        $this->assertSame('VN', $jsonDetails->getPaymentTypeCode());
+        $this->assertSame(0, $jsonDetails->getResponseCode());
+        $this->assertSame(1, $jsonDetails->getInstallmentsNumber());
+        $this->assertSame(500.00, $jsonDetails->getInstallmentsAmount());
+        $this->assertSame('597020000540', $jsonDetails->getCommerceCode());
+        $this->assertSame('567890', $jsonDetails->getBuyOrder());
     }
 
     public function testReturnValueIfExists()

--- a/tests/Webpay/TransaccionCompleta/Responses/MallTransactionInstallmentsResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/MallTransactionInstallmentsResponseTest.php
@@ -15,7 +15,7 @@ class MallTransactionInstallmentsResponseTest extends TestCase
 
         $response = new MallTransactionInstallmentsResponse($json);
 
-        $this->assertSame(1000.0, $response->getInstallmentsAmount());
+        $this->assertSame(1000, $response->getInstallmentsAmount());
         $this->assertSame($json['id_query_installments'], $response->idQueryInstallments);
         $this->assertSame($json['deferred_periods'], $response->deferredPeriods);
     }
@@ -30,7 +30,7 @@ class MallTransactionInstallmentsResponseTest extends TestCase
 
         $response = new MallTransactionInstallmentsResponse($json);
 
-        $this->assertSame(2000.0, $response->getInstallmentsAmount());
+        $this->assertSame(2000, $response->getInstallmentsAmount());
 
         $this->assertSame('456', $response->getIdQueryInstallments());
 

--- a/tests/Webpay/TransaccionCompleta/Responses/MallTransactionInstallmentsResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/MallTransactionInstallmentsResponseTest.php
@@ -9,13 +9,13 @@ class MallTransactionInstallmentsResponseTest extends TestCase
     {
         $json = [
             'installments_amount' => 1000,
-            'id_query_installments' => '123456',
-            'deferred_periods' => 12,
+            'id_query_installments' => '123',
+            'deferred_periods' => [],
         ];
 
         $response = new MallTransactionInstallmentsResponse($json);
 
-        $this->assertSame($json['installments_amount'], $response->getInstallmentsAmount());
+        $this->assertSame(1000.0, $response->getInstallmentsAmount());
         $this->assertSame($json['id_query_installments'], $response->idQueryInstallments);
         $this->assertSame($json['deferred_periods'], $response->deferredPeriods);
     }
@@ -24,16 +24,16 @@ class MallTransactionInstallmentsResponseTest extends TestCase
     {
         $json = [
             'installments_amount' => 2000,
-            'id_query_installments' => '123456',
-            'deferred_periods' => 12,
+            'id_query_installments' => '456',
+            'deferred_periods' => [],
         ];
 
         $response = new MallTransactionInstallmentsResponse($json);
 
-        $this->assertSame(2000, $response->getInstallmentsAmount());
+        $this->assertSame(2000.0, $response->getInstallmentsAmount());
 
-        $this->assertSame('123456', $response->getIdQueryInstallments());
+        $this->assertSame('456', $response->getIdQueryInstallments());
 
-        $this->assertSame(12, $response->getDeferredPeriods());
+        $this->assertSame([], $response->getDeferredPeriods());
     }
 }

--- a/tests/Webpay/TransaccionCompleta/Responses/MallTransactionRefundResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/MallTransactionRefundResponseTest.php
@@ -11,9 +11,9 @@ class MallTransactionRefundResponseTest extends TestCase
             'type' => 'testType',
             'authorization_code' => 'testAuthorizationCode',
             'authorization_date' => 'testAuthorizationDate',
-            'nullified_amount' => 'testNullifiedAmount',
-            'balance' => 'testBalance',
-            'response_code' => 'testResponseCode',
+            'nullified_amount' => 4,
+            'balance' => 2,
+            'response_code' => 0,
         ];
 
         $response = new MallTransactionRefundResponse($json);
@@ -21,9 +21,9 @@ class MallTransactionRefundResponseTest extends TestCase
         $this->assertSame('testType', $response->type);
         $this->assertSame('testAuthorizationCode', $response->authorizationCode);
         $this->assertSame('testAuthorizationDate', $response->authorizationDate);
-        $this->assertSame('testNullifiedAmount', $response->nullifiedAmount);
-        $this->assertSame('testBalance', $response->balance);
-        $this->assertSame('testResponseCode', $response->responseCode);
+        $this->assertSame(4.0, $response->nullifiedAmount);
+        $this->assertSame(2.0, $response->balance);
+        $this->assertSame(0, $response->responseCode);
     }
 
     public function testGetters()
@@ -32,8 +32,8 @@ class MallTransactionRefundResponseTest extends TestCase
             'type' => 'testType',
             'authorization_code' => 'testAuthorizationCode',
             'authorization_date' => 'testAuthorizationDate',
-            'nullified_amount' => 'testNullifiedAmount',
-            'balance' => 'testBalance',
+            'nullified_amount' => 4,
+            'balance' => 2,
             'response_code' => 10,
         ];
 
@@ -45,11 +45,10 @@ class MallTransactionRefundResponseTest extends TestCase
 
         $this->assertSame('testAuthorizationDate', $response->getAuthorizationDate());
 
-        $this->assertSame('testNullifiedAmount', $response->getNullifiedAmount());
+        $this->assertSame(4.0, $response->getNullifiedAmount());
 
-        $this->assertSame('testBalance', $response->getBalance());
+        $this->assertSame(2.0, $response->getBalance());
 
         $this->assertSame(10, $response->getResponseCode());
-
     }
 }

--- a/tests/Webpay/TransaccionCompleta/Responses/MallTransactionRefundResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/MallTransactionRefundResponseTest.php
@@ -21,8 +21,8 @@ class MallTransactionRefundResponseTest extends TestCase
         $this->assertSame('testType', $response->type);
         $this->assertSame('testAuthorizationCode', $response->authorizationCode);
         $this->assertSame('testAuthorizationDate', $response->authorizationDate);
-        $this->assertSame(4.0, $response->nullifiedAmount);
-        $this->assertSame(2.0, $response->balance);
+        $this->assertSame(4, $response->nullifiedAmount);
+        $this->assertSame(2, $response->balance);
         $this->assertSame(0, $response->responseCode);
     }
 
@@ -45,9 +45,9 @@ class MallTransactionRefundResponseTest extends TestCase
 
         $this->assertSame('testAuthorizationDate', $response->getAuthorizationDate());
 
-        $this->assertSame(4.0, $response->getNullifiedAmount());
+        $this->assertSame(4, $response->getNullifiedAmount());
 
-        $this->assertSame(2.0, $response->getBalance());
+        $this->assertSame(2, $response->getBalance());
 
         $this->assertSame(10, $response->getResponseCode());
     }

--- a/tests/Webpay/TransaccionCompleta/Responses/TransactionCreateResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/TransactionCreateResponseTest.php
@@ -18,13 +18,13 @@ class TransactionCompletareateResponseTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_null_when_key_does_not_exist_in_json()
+    public function it_throws_type_error_when_token_does_not_exist_in_json()
     {
-        $json = [];
+        $this->expectException(TypeError::class);
 
+        $json = [];
         $response = new TransactionCreateResponse($json);
 
-        $this->assertNull($response->getToken());
+        $this->assertNotNull($response->getToken());
     }
-
 }

--- a/tests/Webpay/TransaccionCompleta/Responses/TransactionCreateResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/TransactionCreateResponseTest.php
@@ -18,13 +18,12 @@ class TransactionCompletareateResponseTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_type_error_when_token_does_not_exist_in_json()
+    public function it_returns_null_when_key_does_not_exist_in_json()
     {
-        $this->expectException(TypeError::class);
-
         $json = [];
+
         $response = new TransactionCreateResponse($json);
 
-        $this->assertNotNull($response->getToken());
+        $this->assertNull($response->getToken());
     }
 }

--- a/tests/Webpay/TransaccionCompleta/Responses/TransactionDetailTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/TransactionDetailTest.php
@@ -23,17 +23,16 @@ class TransactionDetailTest extends TestCase
 
         $transactionDetail = TransactionDetail::createFromArray($data);
 
-        $this->assertSame($data['amount'], $transactionDetail->amount);
+        $this->assertSame(1000.00, $transactionDetail->amount);
         $this->assertSame($data['status'], $transactionDetail->status);
         $this->assertSame($data['authorization_code'], $transactionDetail->authorizationCode);
         $this->assertSame($data['payment_type_code'], $transactionDetail->paymentTypeCode);
         $this->assertSame($data['response_code'], $transactionDetail->responseCode);
         $this->assertSame($data['installments_number'], $transactionDetail->installmentsNumber);
-        $this->assertSame($data['installments_amount'], $transactionDetail->installmentsAmount);
+        $this->assertSame(1000.00, $transactionDetail->installmentsAmount);
         $this->assertSame($data['commerce_code'], $transactionDetail->commerceCode);
         $this->assertSame($data['buy_order'], $transactionDetail->buyOrder);
-        $this->assertSame($data['balance'], $transactionDetail->balance);
+        $this->assertSame(0.00, $transactionDetail->balance);
         $this->assertSame($data['prepaid_balance'], $transactionDetail->prepaidBalance);
     }
-
 }

--- a/tests/Webpay/TransaccionCompleta/Responses/TransactionDetailTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/TransactionDetailTest.php
@@ -23,16 +23,16 @@ class TransactionDetailTest extends TestCase
 
         $transactionDetail = TransactionDetail::createFromArray($data);
 
-        $this->assertSame(1000.00, $transactionDetail->amount);
+        $this->assertSame(1000, $transactionDetail->amount);
         $this->assertSame($data['status'], $transactionDetail->status);
         $this->assertSame($data['authorization_code'], $transactionDetail->authorizationCode);
         $this->assertSame($data['payment_type_code'], $transactionDetail->paymentTypeCode);
         $this->assertSame($data['response_code'], $transactionDetail->responseCode);
         $this->assertSame($data['installments_number'], $transactionDetail->installmentsNumber);
-        $this->assertSame(1000.00, $transactionDetail->installmentsAmount);
+        $this->assertSame(1000, $transactionDetail->installmentsAmount);
         $this->assertSame($data['commerce_code'], $transactionDetail->commerceCode);
         $this->assertSame($data['buy_order'], $transactionDetail->buyOrder);
-        $this->assertSame(0.00, $transactionDetail->balance);
+        $this->assertSame(0, $transactionDetail->balance);
         $this->assertSame($data['prepaid_balance'], $transactionDetail->prepaidBalance);
     }
 }

--- a/tests/Webpay/TransaccionCompleta/Responses/TransactionInstallmentsResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/TransactionInstallmentsResponseTest.php
@@ -31,6 +31,6 @@ class TransactionInstallmentsResponseTest extends TestCase
 
     public function testGetInstallmentsAmount()
     {
-        $this->assertSame(1000.00, $this->transactionInstallmentsResponse->getInstallmentsAmount());
+        $this->assertSame(1000, $this->transactionInstallmentsResponse->getInstallmentsAmount());
     }
 }

--- a/tests/Webpay/TransaccionCompleta/Responses/TransactionInstallmentsResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/TransactionInstallmentsResponseTest.php
@@ -6,8 +6,8 @@ use Transbank\Webpay\TransaccionCompleta\Responses\TransactionInstallmentsRespon
 class TransactionInstallmentsResponseTest extends TestCase
 {
 
-    protected $json;
-    protected $transactionInstallmentsResponse;
+    protected array $json;
+    protected TransactionInstallmentsResponse $transactionInstallmentsResponse;
 
     public function setUp(): void
     {
@@ -31,6 +31,6 @@ class TransactionInstallmentsResponseTest extends TestCase
 
     public function testGetInstallmentsAmount()
     {
-        $this->assertSame(1000, $this->transactionInstallmentsResponse->getInstallmentsAmount());
+        $this->assertSame(1000.00, $this->transactionInstallmentsResponse->getInstallmentsAmount());
     }
 }

--- a/tests/Webpay/TransaccionCompleta/Responses/TransactionRefundResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/TransactionRefundResponseTest.php
@@ -15,13 +15,12 @@ class TransactionRefundResponseTest extends TestCase
             'type' => 'testType',
             'authorization_code' => 'testAuthorizationCode',
             'authorization_date' => 'testAuthorizationDate',
-            'nullified_amount' => 'testNullifiedAmount',
-            'balance' => 'testBalance',
+            'nullified_amount' => 4,
+            'balance' => 2,
             'response_code' => 200,
         ];
 
         $this->refundResponse = new TransactionRefundResponse($this->json);
-
     }
     public function testConstructor()
     {
@@ -31,8 +30,8 @@ class TransactionRefundResponseTest extends TestCase
         $this->assertEquals('testType', $response->type);
         $this->assertEquals('testAuthorizationCode', $response->authorizationCode);
         $this->assertEquals('testAuthorizationDate', $response->authorizationDate);
-        $this->assertEquals('testNullifiedAmount', $response->nullifiedAmount);
-        $this->assertEquals('testBalance', $response->balance);
+        $this->assertEquals(4, $response->nullifiedAmount);
+        $this->assertEquals(2, $response->balance);
         $this->assertEquals(200, $response->responseCode);
     }
 
@@ -44,11 +43,10 @@ class TransactionRefundResponseTest extends TestCase
 
         $this->assertEquals('testAuthorizationDate', $this->refundResponse->getAuthorizationDate());
 
-        $this->assertEquals('testNullifiedAmount', $this->refundResponse->getNullifiedAmount());
+        $this->assertEquals(4, $this->refundResponse->getNullifiedAmount());
 
-        $this->assertEquals('testBalance', $this->refundResponse->getBalance());
+        $this->assertEquals(2, $this->refundResponse->getBalance());
 
         $this->assertEquals(200, $this->refundResponse->getResponseCode());
     }
-
 }

--- a/tests/Webpay/TransaccionCompleta/Responses/TransactionStatusResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/TransactionStatusResponseTest.php
@@ -11,7 +11,7 @@ class TransactionStatusResponseTest extends TestCase
     {
         $this->json = [
             'vci' => 'Some VCI',
-            'prepaid_balance' => 100.00,
+            'prepaid_balance' => 100,
         ];
         $this->response = $this->getMockBuilder(TransactionStatusResponse::class)
             ->setConstructorArgs([$this->json])
@@ -21,7 +21,7 @@ class TransactionStatusResponseTest extends TestCase
     /** @test */
     public function it_can_get_prepaid_balance()
     {
-        $this->assertSame(100.00, $this->response->getPrepaidBalance());
+        $this->assertSame(100, $this->response->getPrepaidBalance());
     }
 
     /** @test */

--- a/tests/Webpay/TransaccionCompleta/Responses/TransactionStatusResponseTest.php
+++ b/tests/Webpay/TransaccionCompleta/Responses/TransactionStatusResponseTest.php
@@ -5,15 +5,18 @@ use Transbank\Webpay\TransaccionCompleta\Responses\TransactionStatusResponse;
 
 class TransactionStatusResponseTest extends TestCase
 {
-    protected $json;
-    protected $response;
+    protected array $json;
+    protected TransactionStatusResponse $response;
     public function setUp(): void
     {
         $this->json = [
-        'vci' => 'Some VCI',
-        'prepaid_balance' => 100.00
+            'vci' => 'Some VCI',
+            'prepaid_balance' => 100.00,
         ];
-        $this->response = new TransactionStatusResponse($this->json);
+        $this->response = $this->getMockBuilder(TransactionStatusResponse::class)
+            ->setConstructorArgs([$this->json])
+            ->onlyMethods(['setTransactionStatusFields'])
+            ->getMock();
     }
     /** @test */
     public function it_can_get_prepaid_balance()

--- a/tests/Webpay/TransaccionCompleta/TransaccionCompletaTest.php
+++ b/tests/Webpay/TransaccionCompleta/TransaccionCompletaTest.php
@@ -74,7 +74,7 @@ class TransaccionCompletaTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->amount = 1000.0;
+        $this->amount = 1000;
         $this->sessionId = 'some_session_id_' . uniqid();
         $this->buyOrder = '123999555';
         $this->mockBaseUrl = 'https://mockurl.cl';
@@ -227,14 +227,14 @@ class TransaccionCompletaTest extends TestCase
         $this->assertSame(null, $response->getVci());
         $this->assertSame('sesion1234564', $response->getSessionId());
         $this->assertSame('AUTHORIZED', $response->getStatus());
-        $this->assertSame(10000.00, $response->getAmount());
+        $this->assertSame(10000, $response->getAmount());
         $this->assertSame('OrdenCompra55886', $response->getBuyOrder());
         $this->assertSame('6623', $response->getCardNumber());
         $this->assertSame(['card_number' => '6623'], $response->getCardDetail());
         $this->assertSame('1213', $response->getAuthorizationCode());
         $this->assertSame('NC', $response->getPaymentTypeCode());
         $this->assertSame(10, $response->getInstallmentsNumber());
-        $this->assertSame(1000.00, $response->getInstallmentsAmount());
+        $this->assertSame(1000, $response->getInstallmentsAmount());
         $this->assertSame(self::MOCK_TRANSACTION_DATE, $response->getTransactionDate());
         $this->assertSame('0329', $response->getAccountingDate());
     }
@@ -277,14 +277,14 @@ class TransaccionCompletaTest extends TestCase
         $this->assertSame(null, $response->getVci());
         $this->assertSame('sesion1234564', $response->getSessionId());
         $this->assertSame('AUTHORIZED', $response->getStatus());
-        $this->assertSame(10000.00, $response->getAmount());
+        $this->assertSame(10000, $response->getAmount());
         $this->assertSame('OrdenCompra55886', $response->getBuyOrder());
         $this->assertSame('6623', $response->getCardNumber());
         $this->assertSame(['card_number' => '6623'], $response->getCardDetail());
         $this->assertSame('1213', $response->getAuthorizationCode());
         $this->assertSame('NC', $response->getPaymentTypeCode());
         $this->assertSame(10, $response->getInstallmentsNumber());
-        $this->assertSame(1000.00, $response->getInstallmentsAmount());
+        $this->assertSame(1000, $response->getInstallmentsAmount());
         $this->assertSame(self::MOCK_TRANSACTION_DATE, $response->getTransactionDate());
         $this->assertSame('0329', $response->getAccountingDate());
     }

--- a/tests/Webpay/TransaccionCompleta/TransaccionCompletaTest.php
+++ b/tests/Webpay/TransaccionCompleta/TransaccionCompletaTest.php
@@ -20,6 +20,9 @@ use Transbank\Webpay\Options;
 
 class TransaccionCompletaTest extends TestCase
 {
+    const MOCK_SEARCH_STRING = '{token}';
+    const MOCK_TRANSACTION_DATE = '2021-03-29T06:33:32.954Z';
+    const MOCK_ERROR_MESSAGE = 'error message';
     /**
      * @var int
      */
@@ -64,7 +67,6 @@ class TransaccionCompletaTest extends TestCase
     {
         $this->requestServiceMock = $this->createMock(HttpClientRequestService::class);
         $this->optionsMock = $this->createMock(Options::class);
-
         $this->headersMock = ['header_1' => uniqid()];
         $this->optionsMock->method('getApiBaseUrl')->willReturn($this->mockBaseUrl);
         $this->optionsMock->method('getHeaders')->willReturn($this->headersMock);
@@ -72,7 +74,7 @@ class TransaccionCompletaTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->amount = 1000;
+        $this->amount = 1000.0;
         $this->sessionId = 'some_session_id_' . uniqid();
         $this->buyOrder = '123999555';
         $this->mockBaseUrl = 'https://mockurl.cl';
@@ -139,9 +141,9 @@ class TransaccionCompletaTest extends TestCase
                 'buy_order'            => $this->buyOrder,
                 'session_id'           => $this->sessionId,
                 'amount'               => $this->amount,
-                'cvv'                  => $this->cvv,
                 'card_number'          => $this->cardNumber,
                 'card_expiration_date' => $this->cardExpiration,
+                'cvv'                  => $this->cvv,
             ])
             ->willReturn(
                 [
@@ -154,9 +156,9 @@ class TransaccionCompletaTest extends TestCase
             $this->buyOrder,
             $this->sessionId,
             $this->amount,
-            $this->cvv,
             $this->cardNumber,
-            $this->cardExpiration
+            $this->cardExpiration,
+            $this->cvv
         );
         $this->assertInstanceOf(TransactionCreateResponse::class, $response);
         $this->assertEquals($response->getToken(), $tokenMock);
@@ -170,7 +172,7 @@ class TransaccionCompletaTest extends TestCase
         $tokenMock = uniqid();
 
         $this->requestServiceMock->method('request')
-            ->with('POST', str_replace('{token}', $tokenMock, Transaction::ENDPOINT_INSTALLMENTS), [
+            ->with('POST', str_replace(self::MOCK_SEARCH_STRING, $tokenMock, Transaction::ENDPOINT_INSTALLMENTS), [
                 'installments_number' => 2,
             ])
             ->willReturn([
@@ -195,7 +197,7 @@ class TransaccionCompletaTest extends TestCase
         $tokenMock = uniqid();
 
         $expectedUrl = str_replace(
-            '{token}',
+            self::MOCK_SEARCH_STRING,
             $tokenMock,
             Transaction::ENDPOINT_COMMIT
         );
@@ -211,7 +213,7 @@ class TransaccionCompletaTest extends TestCase
                     'card_number' => '6623',
                 ],
                 'accounting_date'     => '0329',
-                'transaction_date'    => '2021-03-29T06:33:32.954Z',
+                'transaction_date'    => self::MOCK_TRANSACTION_DATE,
                 'authorization_code'  => '1213',
                 'payment_type_code'   => 'NC',
                 'response_code'       => 0,
@@ -225,15 +227,15 @@ class TransaccionCompletaTest extends TestCase
         $this->assertSame(null, $response->getVci());
         $this->assertSame('sesion1234564', $response->getSessionId());
         $this->assertSame('AUTHORIZED', $response->getStatus());
-        $this->assertSame(10000, $response->getAmount());
+        $this->assertSame(10000.00, $response->getAmount());
         $this->assertSame('OrdenCompra55886', $response->getBuyOrder());
         $this->assertSame('6623', $response->getCardNumber());
         $this->assertSame(['card_number' => '6623'], $response->getCardDetail());
         $this->assertSame('1213', $response->getAuthorizationCode());
         $this->assertSame('NC', $response->getPaymentTypeCode());
         $this->assertSame(10, $response->getInstallmentsNumber());
-        $this->assertSame(1000, $response->getInstallmentsAmount());
-        $this->assertSame('2021-03-29T06:33:32.954Z', $response->getTransactionDate());
+        $this->assertSame(1000.00, $response->getInstallmentsAmount());
+        $this->assertSame(self::MOCK_TRANSACTION_DATE, $response->getTransactionDate());
         $this->assertSame('0329', $response->getAccountingDate());
     }
 
@@ -245,7 +247,7 @@ class TransaccionCompletaTest extends TestCase
         $tokenMock = uniqid();
 
         $expectedUrl = str_replace(
-            '{token}',
+            self::MOCK_SEARCH_STRING,
             $tokenMock,
             Transaction::ENDPOINT_STATUS
         );
@@ -261,7 +263,7 @@ class TransaccionCompletaTest extends TestCase
                     'card_number' => '6623',
                 ],
                 'accounting_date'     => '0329',
-                'transaction_date'    => '2021-03-29T06:33:32.954Z',
+                'transaction_date'    => self::MOCK_TRANSACTION_DATE,
                 'authorization_code'  => '1213',
                 'payment_type_code'   => 'NC',
                 'response_code'       => 0,
@@ -275,15 +277,15 @@ class TransaccionCompletaTest extends TestCase
         $this->assertSame(null, $response->getVci());
         $this->assertSame('sesion1234564', $response->getSessionId());
         $this->assertSame('AUTHORIZED', $response->getStatus());
-        $this->assertSame(10000, $response->getAmount());
+        $this->assertSame(10000.00, $response->getAmount());
         $this->assertSame('OrdenCompra55886', $response->getBuyOrder());
         $this->assertSame('6623', $response->getCardNumber());
         $this->assertSame(['card_number' => '6623'], $response->getCardDetail());
         $this->assertSame('1213', $response->getAuthorizationCode());
         $this->assertSame('NC', $response->getPaymentTypeCode());
         $this->assertSame(10, $response->getInstallmentsNumber());
-        $this->assertSame(1000, $response->getInstallmentsAmount());
-        $this->assertSame('2021-03-29T06:33:32.954Z', $response->getTransactionDate());
+        $this->assertSame(1000.00, $response->getInstallmentsAmount());
+        $this->assertSame(self::MOCK_TRANSACTION_DATE, $response->getTransactionDate());
         $this->assertSame('0329', $response->getAccountingDate());
     }
 
@@ -299,10 +301,10 @@ class TransaccionCompletaTest extends TestCase
         $this->setBaseMocks();
 
         $this->requestServiceMock->method('request')
-            ->willThrowException(new WebpayRequestException('error message'));
+            ->willThrowException(new WebpayRequestException(self::MOCK_ERROR_MESSAGE));
 
         $this->expectException(TransactionCreateException::class);
-        $this->expectExceptionMessage('error message');
+        $this->expectExceptionMessage(self::MOCK_ERROR_MESSAGE);
         $transaction = new Transaction($this->optionsMock, $this->requestServiceMock);
         $transaction->create($this->buyOrder, $this->sessionId, $this->amount, $this->cvv, $this->cardNumber, $this->cardExpiration);
     }
@@ -313,10 +315,10 @@ class TransaccionCompletaTest extends TestCase
         $this->setBaseMocks();
 
         $this->requestServiceMock->method('request')
-            ->willThrowException(new WebpayRequestException('error message'));
+            ->willThrowException(new WebpayRequestException(self::MOCK_ERROR_MESSAGE));
 
         $this->expectException(TransactionCommitException::class);
-        $this->expectExceptionMessage('error message');
+        $this->expectExceptionMessage(self::MOCK_ERROR_MESSAGE);
         $transaction = new Transaction($this->optionsMock, $this->requestServiceMock);
         $transaction->commit('fakeToken');
     }
@@ -327,10 +329,10 @@ class TransaccionCompletaTest extends TestCase
         $this->setBaseMocks();
 
         $this->requestServiceMock->method('request')
-            ->willThrowException(new WebpayRequestException('error message'));
+            ->willThrowException(new WebpayRequestException(self::MOCK_ERROR_MESSAGE));
 
         $this->expectException(TransactionStatusException::class);
-        $this->expectExceptionMessage('error message');
+        $this->expectExceptionMessage(self::MOCK_ERROR_MESSAGE);
         $transaction = new Transaction($this->optionsMock, $this->requestServiceMock);
         $transaction->status('fakeToken');
     }
@@ -341,12 +343,12 @@ class TransaccionCompletaTest extends TestCase
         $this->setBaseMocks();
 
         $this->requestServiceMock->method('request')
-            ->willThrowException(new WebpayRequestException('error message'));
+            ->willThrowException(new WebpayRequestException(self::MOCK_ERROR_MESSAGE));
 
         $this->expectException(TransactionRefundException::class);
-        $this->expectExceptionMessage('error message');
+        $this->expectExceptionMessage(self::MOCK_ERROR_MESSAGE);
         $transaction = new Transaction($this->optionsMock, $this->requestServiceMock);
-        $transaction->refund('fakeToken', 'buyOrder', 'comemrceCode', 1400);
+        $transaction->refund('fakeToken', 123);
     }
 
     /** @test */
@@ -355,10 +357,10 @@ class TransaccionCompletaTest extends TestCase
         $this->setBaseMocks();
 
         $this->requestServiceMock->method('request')
-            ->willThrowException(new WebpayRequestException('error message'));
+            ->willThrowException(new WebpayRequestException(self::MOCK_ERROR_MESSAGE));
 
         $this->expectException(TransactionInstallmentsException::class);
-        $this->expectExceptionMessage('error message');
+        $this->expectExceptionMessage(self::MOCK_ERROR_MESSAGE);
         $transaction = new Transaction($this->optionsMock, $this->requestServiceMock);
         $transaction->installments('fakeToken', 2);
     }

--- a/tests/Webpay/WebpayPlus/WebpayMallTransactionTest.php
+++ b/tests/Webpay/WebpayPlus/WebpayMallTransactionTest.php
@@ -19,6 +19,7 @@ use Transbank\Webpay\WebpayPlus\Transaction;
 
 class WebpayMallTransactionTest extends TestCase
 {
+    const MOCK_ERROR_MESSAGE = 'error message';
     /**
      * @var int
      */
@@ -165,7 +166,7 @@ class WebpayMallTransactionTest extends TestCase
         );
 
         $this->requestServiceMock->method('request')
-            ->with('PUT', $expectedUrl, null)
+            ->with('PUT', $expectedUrl, [])
             ->willReturn([
                 'vci'     => 'TSY',
                 'details' => [
@@ -216,7 +217,7 @@ class WebpayMallTransactionTest extends TestCase
         $this->assertSame('2021-03-29T04:47:19.885Z', $response->getTransactionDate());
         $this->assertSame(0, $firstDetail->getResponseCode());
         $this->assertSame('AUTHORIZED', $firstDetail->getStatus());
-        $this->assertSame(1000, $firstDetail->getAmount());
+        $this->assertSame(1000.00, $firstDetail->getAmount());
         $this->assertSame('1213', $firstDetail->getAuthorizationCode());
         $this->assertSame('VN', $firstDetail->getPaymentTypeCode());
         $this->assertSame(0, $firstDetail->getInstallmentsNumber());
@@ -225,7 +226,7 @@ class WebpayMallTransactionTest extends TestCase
         $this->assertSame('OrdenCompraChild_66986_1', $firstDetail->getBuyOrder());
         $this->assertSame(0, $secondDetail->getResponseCode());
         $this->assertSame('AUTHORIZED', $secondDetail->getStatus());
-        $this->assertSame(2000, $secondDetail->getAmount());
+        $this->assertSame(2000.00, $secondDetail->getAmount());
         $this->assertSame('1213', $secondDetail->getAuthorizationCode());
         $this->assertSame('VN', $secondDetail->getPaymentTypeCode());
         $this->assertSame(0, $secondDetail->getInstallmentsNumber());
@@ -246,12 +247,12 @@ class WebpayMallTransactionTest extends TestCase
         $this->setBaseMocks();
 
         $this->requestServiceMock->method('request')
-            ->willThrowException(new WebpayRequestException('error message'));
+            ->willThrowException(new WebpayRequestException(self::MOCK_ERROR_MESSAGE));
 
         $this->expectException(MallTransactionCreateException::class);
-        $this->expectExceptionMessage('error message');
+        $this->expectExceptionMessage(self::MOCK_ERROR_MESSAGE);
         $transaction = new MallTransaction($this->optionsMock, $this->requestServiceMock);
-        $transaction->create($this->buyOrder, $this->sessionId, $this->amount, null);
+        $transaction->create($this->buyOrder, $this->sessionId, $this->amount, []);
     }
 
     /** @test */
@@ -260,10 +261,10 @@ class WebpayMallTransactionTest extends TestCase
         $this->setBaseMocks();
 
         $this->requestServiceMock->method('request')
-            ->willThrowException(new WebpayRequestException('error message'));
+            ->willThrowException(new WebpayRequestException(self::MOCK_ERROR_MESSAGE));
 
         $this->expectException(MallTransactionCommitException::class);
-        $this->expectExceptionMessage('error message');
+        $this->expectExceptionMessage(self::MOCK_ERROR_MESSAGE);
         $transaction = new MallTransaction($this->optionsMock, $this->requestServiceMock);
         $transaction->commit('fakeToken');
     }
@@ -274,10 +275,10 @@ class WebpayMallTransactionTest extends TestCase
         $this->setBaseMocks();
 
         $this->requestServiceMock->method('request')
-            ->willThrowException(new WebpayRequestException('error message'));
+            ->willThrowException(new WebpayRequestException(self::MOCK_ERROR_MESSAGE));
 
         $this->expectException(MallTransactionStatusException::class);
-        $this->expectExceptionMessage('error message');
+        $this->expectExceptionMessage(self::MOCK_ERROR_MESSAGE);
         $transaction = new MallTransaction($this->optionsMock, $this->requestServiceMock);
         $transaction->status('fakeToken');
     }
@@ -288,10 +289,10 @@ class WebpayMallTransactionTest extends TestCase
         $this->setBaseMocks();
 
         $this->requestServiceMock->method('request')
-            ->willThrowException(new WebpayRequestException('error message'));
+            ->willThrowException(new WebpayRequestException(self::MOCK_ERROR_MESSAGE));
 
         $this->expectException(MallTransactionRefundException::class);
-        $this->expectExceptionMessage('error message');
+        $this->expectExceptionMessage(self::MOCK_ERROR_MESSAGE);
         $transaction = new MallTransaction($this->optionsMock, $this->requestServiceMock);
         $transaction->refund('fakeToken', 'buyOrder', 'comemrceCode', 1400);
     }
@@ -302,10 +303,10 @@ class WebpayMallTransactionTest extends TestCase
         $this->setBaseMocks();
 
         $this->requestServiceMock->method('request')
-            ->willThrowException(new WebpayRequestException('error message'));
+            ->willThrowException(new WebpayRequestException(self::MOCK_ERROR_MESSAGE));
 
         $this->expectException(MallTransactionCaptureException::class);
-        $this->expectExceptionMessage('error message');
+        $this->expectExceptionMessage(self::MOCK_ERROR_MESSAGE);
         $transaction = new MallTransaction($this->optionsMock, $this->requestServiceMock);
         $transaction->capture('fake', 'fake', 'fake', '1203', 1000);
     }

--- a/tests/Webpay/WebpayPlus/WebpayMallTransactionTest.php
+++ b/tests/Webpay/WebpayPlus/WebpayMallTransactionTest.php
@@ -217,7 +217,7 @@ class WebpayMallTransactionTest extends TestCase
         $this->assertSame('2021-03-29T04:47:19.885Z', $response->getTransactionDate());
         $this->assertSame(0, $firstDetail->getResponseCode());
         $this->assertSame('AUTHORIZED', $firstDetail->getStatus());
-        $this->assertSame(1000.00, $firstDetail->getAmount());
+        $this->assertSame(1000, $firstDetail->getAmount());
         $this->assertSame('1213', $firstDetail->getAuthorizationCode());
         $this->assertSame('VN', $firstDetail->getPaymentTypeCode());
         $this->assertSame(0, $firstDetail->getInstallmentsNumber());
@@ -226,7 +226,7 @@ class WebpayMallTransactionTest extends TestCase
         $this->assertSame('OrdenCompraChild_66986_1', $firstDetail->getBuyOrder());
         $this->assertSame(0, $secondDetail->getResponseCode());
         $this->assertSame('AUTHORIZED', $secondDetail->getStatus());
-        $this->assertSame(2000.00, $secondDetail->getAmount());
+        $this->assertSame(2000, $secondDetail->getAmount());
         $this->assertSame('1213', $secondDetail->getAuthorizationCode());
         $this->assertSame('VN', $secondDetail->getPaymentTypeCode());
         $this->assertSame(0, $secondDetail->getInstallmentsNumber());

--- a/tests/Webpay/WebpayPlus/WebpayPlusTransactionTest.php
+++ b/tests/Webpay/WebpayPlus/WebpayPlusTransactionTest.php
@@ -235,14 +235,9 @@ class WebpayPlusTransactionTest extends TestCase
             ->willReturn([]);
 
         $transaction = new Transaction($this->optionsMock, $this->requestServiceMock);
-        $errorCaught = false;
-        try {
-            $transaction->commit($tokenMock);
-        } catch (\TypeError $e) {
-            $this->assertStringContainsString('Cannot assign null to property', $e->getMessage());
-            $errorCaught = true;
-        }
-        $this->assertTrue($errorCaught, "Expected TypeError was not caught");
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('Argument #1 ($json) must be of type array');
+        $transaction->commit($tokenMock);
     }
 
     /** @test */

--- a/tests/Webpay/WebpayPlus/WebpayPlusTransactionTest.php
+++ b/tests/Webpay/WebpayPlus/WebpayPlusTransactionTest.php
@@ -218,29 +218,6 @@ class WebpayPlusTransactionTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_type_error_on_null_assignments()
-    {
-        $this->setBaseMocks();
-
-        $tokenMock = uniqid();
-
-        $expectedUrl = str_replace(
-            '{token}',
-            $tokenMock,
-            Transaction::ENDPOINT_COMMIT
-        );
-
-        $this->requestServiceMock->method('request')
-            ->with('PUT', $expectedUrl, [])
-            ->willReturn([]);
-
-        $transaction = new Transaction($this->optionsMock, $this->requestServiceMock);
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Argument #1 ($json) must be of type array');
-        $transaction->commit($tokenMock);
-    }
-
-    /** @test */
     public function it_throws_and_exception_if_transaction_creations_fails()
     {
         $this->setBaseMocks();

--- a/tests/Webpay/WebpayPlus/WebpayPlusTransactionTest.php
+++ b/tests/Webpay/WebpayPlus/WebpayPlusTransactionTest.php
@@ -205,7 +205,7 @@ class WebpayPlusTransactionTest extends TestCase
         $this->assertSame('TSY', $response->getVci());
         $this->assertSame('session1234564', $response->getSessionId());
         $this->assertSame('AUTHORIZED', $response->getStatus());
-        $this->assertSame(1000.0, $response->getAmount());
+        $this->assertSame(1000, $response->getAmount());
         $this->assertSame('OrdenCompra36271', $response->getBuyOrder());
         $this->assertSame('6623', $response->getCardNumber());
         $this->assertSame(['card_number' => '6623'], $response->getCardDetail());


### PR DESCRIPTION
Review this PR first: https://github.com/TransbankDevelopers/transbank-sdk-php/pull/285

Here all the tests are corrected after uploading the php version and typing all the variables
![image](https://github.com/TransbankDevelopers/transbank-sdk-php/assets/59769869/7941eb11-12b0-441d-8a72-56476bf115a2)
