### PR TITLE
refactor: change php docs imports

### DIFF
--- a/src/Contracts/HttpClientInterface.php
+++ b/src/Contracts/HttpClientInterface.php
@@ -3,7 +3,6 @@
 namespace Transbank\Contracts;
 
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Exception\GuzzleException;
 
 interface HttpClientInterface
 {
@@ -13,7 +12,7 @@ interface HttpClientInterface
      * @param array|null $payload
      * @param array|null $options
      *
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return ResponseInterface
      */

--- a/src/Contracts/RequestService.php
+++ b/src/Contracts/RequestService.php
@@ -3,7 +3,6 @@
 namespace Transbank\Contracts;
 
 use Transbank\Webpay\Options;
-use Transbank\Webpay\Exceptions\WebpayRequestException;
 use Psr\Http\Message\ResponseInterface;
 use Transbank\Webpay\Exceptions\TransbankApiRequest;
 
@@ -15,7 +14,7 @@ interface RequestService
      * @param array   $payload
      * @param Options $options
      *
-     * @throws WebpayRequestException
+     * @throws \Transbank\Webpay\Exceptions\WebpayRequestException
      *
      * @return array Response from the API as json.
      */

--- a/src/PatpassComercio/Inscription.php
+++ b/src/PatpassComercio/Inscription.php
@@ -17,7 +17,6 @@ use Transbank\Utils\HttpClientRequestService;
 use Transbank\Utils\RequestServiceTrait;
 use Transbank\Contracts\RequestService;
 use Transbank\PatpassComercio\Options;
-use GuzzleHttp\Exception\GuzzleException;
 
 class Inscription
 {
@@ -63,7 +62,7 @@ class Inscription
      * @param string $city
      *
      * @throws InscriptionStartException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return InscriptionStartResponse
      */
@@ -123,7 +122,7 @@ class Inscription
      * @param string $token
      *
      * @throws InscriptionStatusException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return InscriptionStatusResponse
      */

--- a/src/Utils/HttpClient.php
+++ b/src/Utils/HttpClient.php
@@ -5,7 +5,6 @@ namespace Transbank\Utils;
 use Composer\InstalledVersions;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Exception\GuzzleException;
 use Transbank\Contracts\HttpClientInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -18,7 +17,7 @@ class HttpClient implements HttpClientInterface
      * @param array|null $payload
      * @param array|null $options
      *
-     *@throws GuzzleException
+     *@throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return ResponseInterface
      */
@@ -65,7 +64,7 @@ class HttpClient implements HttpClientInterface
      * @param string|null $payload
      * @param int     $timeout
      *
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return ResponseInterface
      */

--- a/src/Utils/HttpClientRequestService.php
+++ b/src/Utils/HttpClientRequestService.php
@@ -7,7 +7,6 @@ use Transbank\Contracts\RequestService;
 use Transbank\Webpay\Exceptions\TransbankApiRequest;
 use Transbank\Webpay\Exceptions\WebpayRequestException;
 use Transbank\Webpay\Options;
-use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
 
 class HttpClientRequestService implements RequestService
@@ -56,7 +55,7 @@ class HttpClientRequestService implements RequestService
      * @param array   $payload
      * @param Options $options
      *
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws WebpayRequestException
      *
      * @return array

--- a/src/Utils/RequestServiceTrait.php
+++ b/src/Utils/RequestServiceTrait.php
@@ -3,7 +3,6 @@
 namespace Transbank\Utils;
 
 use Transbank\Contracts\RequestService;
-use Transbank\Webpay\Exceptions\WebpayRequestException;
 
 /**
  * Trait RequestServiceTrait .
@@ -21,7 +20,7 @@ trait RequestServiceTrait
      * @param string $endpoint
      * @param array  $payload
      *
-     * @throws WebpayRequestException
+     * @throws \Transbank\Webpay\Exceptions\WebpayRequestException
      *
      * @return array
      */

--- a/src/Webpay/Oneclick/MallInscription.php
+++ b/src/Webpay/Oneclick/MallInscription.php
@@ -10,7 +10,6 @@ use Transbank\Webpay\Oneclick\Exceptions\InscriptionStartException;
 use Transbank\Webpay\Oneclick\Responses\InscriptionDeleteResponse;
 use Transbank\Webpay\Oneclick\Responses\InscriptionFinishResponse;
 use Transbank\Webpay\Oneclick\Responses\InscriptionStartResponse;
-use GuzzleHttp\Exception\GuzzleException;
 
 class MallInscription
 {
@@ -28,7 +27,7 @@ class MallInscription
      * @return InscriptionStartResponse
      *
      * @throws InscriptionStartException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function start(string $username, string $email, string $responseUrl): InscriptionStartResponse
     {
@@ -63,7 +62,7 @@ class MallInscription
      * @return InscriptionFinishResponse
      *
      * @throws InscriptionFinishException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function finish(string $token): InscriptionFinishResponse
     {
@@ -93,7 +92,7 @@ class MallInscription
      * @return InscriptionDeleteResponse
      *
      * @throws InscriptionDeleteException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function delete(string $tbkUser, string $username): InscriptionDeleteResponse
     {

--- a/src/Webpay/Oneclick/MallTransaction.php
+++ b/src/Webpay/Oneclick/MallTransaction.php
@@ -12,7 +12,6 @@ use Transbank\Webpay\Oneclick\Responses\MallTransactionAuthorizeResponse;
 use Transbank\Webpay\Oneclick\Responses\MallTransactionCaptureResponse;
 use Transbank\Webpay\Oneclick\Responses\MallTransactionRefundResponse;
 use Transbank\Webpay\Oneclick\Responses\MallTransactionStatusResponse;
-use GuzzleHttp\Exception\GuzzleException;
 
 class MallTransaction
 {
@@ -31,7 +30,7 @@ class MallTransaction
      * @return MallTransactionAuthorizeResponse
      *
      * @throws MallTransactionAuthorizeException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function authorize(
         string $userName,
@@ -74,7 +73,7 @@ class MallTransaction
      * @return MallTransactionCaptureResponse
      *
      * @throws MallTransactionCaptureException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function capture(
         string $childCommerceCode,
@@ -114,7 +113,7 @@ class MallTransaction
      * @return MallTransactionStatusResponse
      *
      * @throws MallTransactionStatusException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function status(string $buyOrder): MallTransactionStatusResponse
     {
@@ -146,7 +145,7 @@ class MallTransaction
      * @return MallTransactionRefundResponse
      *
      * @throws MallRefundTransactionException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      */
     public function refund(
         string $buyOrder,

--- a/src/Webpay/TransaccionCompleta/MallTransaction.php
+++ b/src/Webpay/TransaccionCompleta/MallTransaction.php
@@ -21,7 +21,6 @@ use Transbank\Webpay\TransaccionCompleta\Responses\MallTransactionRefundResponse
 use Transbank\Webpay\TransaccionCompleta\Responses\MallTransactionStatusResponse;
 use Transbank\Webpay\TransaccionCompleta\Responses\MallTransactionCaptureResponse;
 use Transbank\Utils\InteractsWithWebpayApi;
-use GuzzleHttp\Exception\GuzzleException;
 use Transbank\Webpay\Exceptions\WebpayRequestException;
 
 class MallTransaction
@@ -224,7 +223,7 @@ class MallTransaction
      * @param int|float  $captureAmount
      *
      * @throws MallTransactionCaptureException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return MallTransactionCaptureResponse
      */

--- a/src/Webpay/TransaccionCompleta/Transaction.php
+++ b/src/Webpay/TransaccionCompleta/Transaction.php
@@ -16,7 +16,6 @@ use Transbank\Webpay\TransaccionCompleta\Responses\TransactionStatusResponse;
 use Transbank\Webpay\TransaccionCompleta\Responses\TransactionCaptureResponse;
 use Transbank\Utils\InteractsWithWebpayApi;
 use Transbank\Webpay\Exceptions\WebpayRequestException;
-use GuzzleHttp\Exception\GuzzleException;
 
 /**
  * Class Transaction.
@@ -42,7 +41,7 @@ class Transaction
      * @param string|null   $cvv
      *
      * @throws TransactionCreateException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionCreateResponse
      */
@@ -83,7 +82,7 @@ class Transaction
      * @param int    $installmentsNumber
      *
      * @throws TransactionInstallmentsException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionInstallmentsResponse
      */
@@ -119,7 +118,7 @@ class Transaction
      * @param bool|null     $gracePeriod
      *
      * @throws TransactionCommitException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionCommitResponse
      */
@@ -157,7 +156,7 @@ class Transaction
      * @param int|float $amount
      *
      * @throws TransactionRefundException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionRefundResponse
      */
@@ -188,7 +187,7 @@ class Transaction
      * @param string $token
      *
      * @throws TransactionStatusException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionStatusResponse
      */
@@ -218,7 +217,7 @@ class Transaction
      * @param int|float $captureAmount
      *
      * @throws TransactionCaptureException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionCaptureResponse
      */

--- a/src/Webpay/WebpayPlus/MallTransaction.php
+++ b/src/Webpay/WebpayPlus/MallTransaction.php
@@ -4,8 +4,6 @@ namespace Transbank\Webpay\WebpayPlus;
 
 use Transbank\Utils\InteractsWithWebpayApi;
 use Transbank\Webpay\Exceptions\WebpayRequestException;
-use Transbank\Webpay\Options;
-use Transbank\Webpay\WebpayPlus;
 use Transbank\Webpay\WebpayPlus\Exceptions\MallTransactionCaptureException;
 use Transbank\Webpay\WebpayPlus\Exceptions\MallTransactionCommitException;
 use Transbank\Webpay\WebpayPlus\Exceptions\MallTransactionCreateException;
@@ -16,7 +14,6 @@ use Transbank\Webpay\WebpayPlus\Responses\MallTransactionCommitResponse;
 use Transbank\Webpay\WebpayPlus\Responses\MallTransactionCreateResponse;
 use Transbank\Webpay\WebpayPlus\Responses\MallTransactionRefundResponse;
 use Transbank\Webpay\WebpayPlus\Responses\MallTransactionStatusResponse;
-use GuzzleHttp\Exception\GuzzleException;
 
 class MallTransaction
 {
@@ -36,7 +33,7 @@ class MallTransaction
      * @param array $details
      *
      * @throws MallTransactionCreateException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return MallTransactionCreateResponse
      */
@@ -72,7 +69,7 @@ class MallTransaction
      * @param string $token
      *
      * @throws MallTransactionCommitException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return MallTransactionCommitResponse
      */
@@ -111,7 +108,7 @@ class MallTransaction
      * @param int|float $amount
      *
      * @throws MallTransactionRefundException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return MallTransactionRefundResponse
      */
@@ -146,7 +143,7 @@ class MallTransaction
      * @param string $token
      *
      * @throws MallTransactionStatusException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return MallTransactionStatusResponse
      */
@@ -179,7 +176,7 @@ class MallTransaction
      * @param int|float $captureAmount
      *
      * @throws MallTransactionCaptureException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return MallTransactionCaptureResponse
      */

--- a/src/Webpay/WebpayPlus/Transaction.php
+++ b/src/Webpay/WebpayPlus/Transaction.php
@@ -3,7 +3,6 @@
 namespace Transbank\Webpay\WebpayPlus;
 
 use Transbank\Utils\InteractsWithWebpayApi;
-use GuzzleHttp\Exception\GuzzleException;
 use Transbank\Webpay\Exceptions\WebpayRequestException;
 use Transbank\Webpay\WebpayPlus\Exceptions\TransactionCaptureException;
 use Transbank\Webpay\WebpayPlus\Exceptions\TransactionCommitException;
@@ -43,7 +42,7 @@ class Transaction
      * @param string    $returnUrl
      *
      * @throws TransactionCreateException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionCreateResponse
      */
@@ -79,7 +78,7 @@ class Transaction
      * @param string $token
      *
      * @throws TransactionCommitException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionCommitResponse
      */
@@ -116,7 +115,7 @@ class Transaction
      * @param int|float  $amount
      *
      * @throws TransactionRefundException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionRefundResponse
      */
@@ -145,7 +144,7 @@ class Transaction
      * @param string $token
      *
      * @throws TransactionStatusException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionStatusResponse
      */
@@ -177,7 +176,7 @@ class Transaction
      * @param int|float  $captureAmount
      *
      * @throws TransactionCaptureException
-     * @throws GuzzleException
+     * @throws \GuzzleHttp\Exception\GuzzleException
      *
      * @return TransactionCaptureResponse
      */

--- a/tests/Webpay/TransaccionCompleta/TransaccionCompletaTest.php
+++ b/tests/Webpay/TransaccionCompleta/TransaccionCompletaTest.php
@@ -12,7 +12,6 @@ use Transbank\Webpay\TransaccionCompleta\Responses\TransactionCommitResponse;
 use Transbank\Webpay\TransaccionCompleta\Responses\TransactionCreateResponse;
 use Transbank\Webpay\TransaccionCompleta\Responses\TransactionInstallmentsResponse;
 use Transbank\Webpay\TransaccionCompleta\Responses\TransactionStatusResponse;
-use Transbank\Webpay\TransaccionCompleta\TransaccionCompleta;
 use Transbank\Webpay\TransaccionCompleta\Transaction;
 use Transbank\Utils\HttpClientRequestService;
 use Transbank\Webpay\Exceptions\WebpayRequestException;

--- a/tests/Webpay/WebpayPlus/WebpayMallTransactionTest.php
+++ b/tests/Webpay/WebpayPlus/WebpayMallTransactionTest.php
@@ -15,7 +15,6 @@ use Transbank\Webpay\WebpayPlus\Exceptions\MallTransactionStatusException;
 use Transbank\Webpay\WebpayPlus\MallTransaction;
 use Transbank\Webpay\WebpayPlus\Responses\MallTransactionCommitResponse;
 use Transbank\Webpay\WebpayPlus\Responses\MallTransactionCreateResponse;
-use Transbank\Webpay\WebpayPlus\Transaction;
 
 class WebpayMallTransactionTest extends TestCase
 {


### PR DESCRIPTION
Imports that are only being used in phpDocs comments are removed to eliminate kiuwan alerts

**Waiting for the result of kiuwan to attach evidence