### PR TITLE
refactor: move transbank api request to utils folder

### DIFF
--- a/src/Contracts/RequestService.php
+++ b/src/Contracts/RequestService.php
@@ -5,7 +5,7 @@ namespace Transbank\Contracts;
 use Transbank\Webpay\Options;
 use Transbank\Webpay\Exceptions\WebpayRequestException;
 use Psr\Http\Message\ResponseInterface;
-use Transbank\Webpay\Exceptions\TransbankApiRequest;
+use Transbank\Utils\TransbankApiRequest;
 
 interface RequestService
 {

--- a/src/Utils/HttpClientRequestService.php
+++ b/src/Utils/HttpClientRequestService.php
@@ -4,7 +4,7 @@ namespace Transbank\Utils;
 
 use Transbank\Contracts\HttpClientInterface;
 use Transbank\Contracts\RequestService;
-use Transbank\Webpay\Exceptions\TransbankApiRequest;
+use Transbank\Utils\TransbankApiRequest;
 use Transbank\Webpay\Exceptions\WebpayRequestException;
 use Transbank\Webpay\Options;
 use GuzzleHttp\Exception\GuzzleException;

--- a/src/Utils/TransbankApiRequest.php
+++ b/src/Utils/TransbankApiRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Transbank\Webpay\Exceptions;
+namespace Transbank\Utils;
 
 class TransbankApiRequest
 {

--- a/src/Webpay/Exceptions/WebpayRequestException.php
+++ b/src/Webpay/Exceptions/WebpayRequestException.php
@@ -2,6 +2,8 @@
 
 namespace Transbank\Webpay\Exceptions;
 
+use Transbank\Utils\TransbankApiRequest;
+
 /**
  * Class WebpayRequestException.
  */

--- a/tests/RequestServiceTest.php
+++ b/tests/RequestServiceTest.php
@@ -27,8 +27,10 @@ class RequestServiceTest extends TestCase
         $httpClientMock
             ->expects($this->once())
             ->method('request')
-            ->with($this->anything(), $this->anything(), $this->anything(), $this->equalTo(['headers' => $expectedHeaders,
-                                                                                            'timeout' => $timeOut]))
+            ->with($this->anything(), $this->anything(), $this->anything(), $this->equalTo([
+                'headers' => $expectedHeaders,
+                'timeout' => $timeOut
+            ]))
             ->willReturn(
                 new Response(200, [], json_encode(['token' => 'mock', 'url'   => 'https://mock.cl/',]))
             );
@@ -69,5 +71,29 @@ class RequestServiceTest extends TestCase
             ->willReturn(new Response(204));
         $response = (new HttpClientRequestService($httpClientMock))->request('DELETE', '/inscriptions', [], $options);
         $this->assertSame([], $response);
+    }
+
+    /** @test */
+    public function it_returns_an_api_request()
+    {
+        $options = new Options('ApiKey', 'commerceCode', Options::ENVIRONMENT_INTEGRATION);
+        $httpClientMock = $this->createMock(HttpClient::class);
+        $httpClientMock
+            ->expects($this->once())
+            ->method('request')
+            ->willReturn(new Response(204));
+
+        $httpClientRequestService = (new HttpClientRequestService($httpClientMock));
+        $httpClientRequestService->request('DELETE', '/inscriptions', [], $options);
+        $request = $httpClientRequestService->getLastRequest();
+
+        $this->assertSame(Options::BASE_URL_INTEGRATION, $request->getBaseUrl());
+        $this->assertSame('/inscriptions', $request->getEndpoint());
+        $this->assertSame([
+            'Tbk-Api-Key-Id' => 'commerceCode',
+            'Tbk-Api-Key-Secret' => 'ApiKey'
+        ], $request->getHeaders());
+        $this->assertSame('DELETE', $request->getMethod());
+        $this->assertSame([], $request->getPayload());
     }
 }

--- a/tests/Webpay/WebpayPlus/Exceptions/WebpayRequestExceptionTest.php
+++ b/tests/Webpay/WebpayPlus/Exceptions/WebpayRequestExceptionTest.php
@@ -2,7 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use Transbank\Webpay\Exceptions\WebpayRequestException;
-use Transbank\Webpay\Exceptions\TransbankApiRequest;
+use Transbank\Utils\TransbankApiRequest;
 
 class WebpayRequestExceptionTest extends TestCase
 {


### PR DESCRIPTION
This PR move the class TransbankApi Request to Utils folder.

## Tests
<img width="703" alt="image" src="https://github.com/user-attachments/assets/419bcbee-3ab5-4e50-917f-db8ab9c20c80">
